### PR TITLE
Update digest to 0.8, refactor for API changes, remove redundant crate

### DIFF
--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -17,15 +17,14 @@ name = "hkdf"
 path = "src/hkdf.rs"
 
 [dependencies]
-generic-array = "0.9"
-digest = "0.7"
-hmac = "0.6"
+digest = "0.8"
+hmac = "0.7"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"
 hex = "0.3.*"
-sha-1 = "0.7.*"
-sha2 = "0.7.*"
+sha-1 = "0.8.*"
+sha2 = "0.8.*"
 bencher = "0.1"
 
 [[bench]]


### PR DESCRIPTION
This PR updates the `digest` dependency to version 0.8 (newest), and includes various refactorings to support this change. More crates start depending on these newer `digest` and `hmac` versions, thus an update is required. This might be considered breaking, as the set of required traits has changed caused by `hmac`. This PR does solve issue #20 .

The following crates have been updated to their newest version:
- `digest`
- `hmac`
- `sha-1` (dev)
- `sha2` (dev)

I've removed `generic-array` as it seems to be redundant, it is re-exported/provided by `digest` now.

Note that on line [60](https://github.com/RustCrypto/KDFs/pull/21/files#diff-8e1d132c798e3b404ba8500b057d1e80R60) in `hkdf.rs`, I've replaced `result().code()` with `result_reset().code()` as Rust was complaining about use-after-move issues, because the old `result()` consumes the `hmac`. I'm not 100% if this change is correct, this might introduce an extra clone, I don't know.

Unit tests and benchmarks succeed on `rustc 1.29.2 (17a9dc751 2018-10-05)` and `rustc 1.31.0-nightly (4699283c5 2018-10-13)`.