### PR TITLE
Support HKDF-Expand with different sized PRKs

### DIFF
--- a/hkdf/benches/hkdf.rs
+++ b/hkdf/benches/hkdf.rs
@@ -9,19 +9,19 @@ use sha2::Sha256;
 
 fn sha256_10(b: &mut Bencher) {
     let mut okm = vec![0u8; 10];
-    b.iter(|| Hkdf::<Sha256>::extract(Some(&[]), &[]).expand(&[], &mut okm));
+    b.iter(|| Hkdf::<Sha256>::new(Some(&[]), &[]).expand(&[], &mut okm));
     b.bytes = 10u64;
 }
 
 fn sha256_1k(b: &mut Bencher) {
     let mut okm = vec![0u8; 1024];
-    b.iter(|| Hkdf::<Sha256>::extract(Some(&[]), &[]).expand(&[], &mut okm));
+    b.iter(|| Hkdf::<Sha256>::new(Some(&[]), &[]).expand(&[], &mut okm));
     b.bytes = 1024u64;
 }
 
 fn sha256_8k(b: &mut Bencher) {
     let mut okm = vec![0u8; 8000];
-    b.iter(|| Hkdf::<Sha256>::extract(Some(&[]), &[]).expand(&[], &mut okm));
+    b.iter(|| Hkdf::<Sha256>::new(Some(&[]), &[]).expand(&[], &mut okm));
     b.bytes = 8000u64;
 }
 

--- a/hkdf/examples/main.rs
+++ b/hkdf/examples/main.rs
@@ -10,11 +10,11 @@ fn main() {
     let salt = hex::decode("000102030405060708090a0b0c").unwrap();
     let info = hex::decode("f0f1f2f3f4f5f6f7f8f9").unwrap();
 
-    let hk = Hkdf::<Sha256>::extract(Some(&salt[..]), &ikm);
+    let (prk, hk) = Hkdf::<Sha256>::extract(Some(&salt[..]), &ikm);
     let mut okm = [0u8; 42];
-    hk.expand(&info, &mut okm).unwrap(); //Will never fail as 42 is a valid length for Sha256 to output
+    hk.expand(&info, &mut okm).expect("42 is a valid length for Sha256 to output");
 
-    println!("Vector 1 PRK is {}", hex::encode(hk.prk));
+    println!("Vector 1 PRK is {}", hex::encode(prk));
     println!("Vector 1 OKM is {}", hex::encode(&okm[..]));
     println!("Matched with https://tools.ietf.org/html/rfc5869#appendix-A.1");
 

--- a/hkdf/src/hkdf.rs
+++ b/hkdf/src/hkdf.rs
@@ -15,10 +15,10 @@
 //! let salt = hex::decode("000102030405060708090a0b0c").unwrap();
 //! let info = hex::decode("f0f1f2f3f4f5f6f7f8f9").unwrap();
 //!
-//! let hk = Hkdf::<Sha256>::extract(Some(&salt[..]), &ikm);
+//! let (prk, hk) = Hkdf::<Sha256>::extract(Some(&salt[..]), &ikm);
 //! let mut okm = [0u8; 42];
 //! hk.expand(&info, &mut okm).unwrap();
-//! println!("PRK is {}", hex::encode(hk.prk));
+//! println!("PRK is {}", hex::encode(prk));
 //! println!("OKM is {}", hex::encode(&okm[..]));
 //! # }
 //! ```
@@ -28,12 +28,17 @@
 
 extern crate digest;
 extern crate hmac;
-#[cfg(feature = "std")] extern crate std;
+#[cfg(feature = "std")]
+extern crate std;
 
-use digest::{BlockInput, FixedOutput, Input, Reset};
-use digest::generic_array::{self, ArrayLength, GenericArray};
-use hmac::{Hmac, Mac};
 use core::fmt;
+use digest::generic_array::{self, ArrayLength, GenericArray};
+use digest::{BlockInput, FixedOutput, Input, Reset};
+use hmac::{Hmac, Mac};
+
+/// Error that is returned when supplied pseudorandom key (PRK) is not long enough.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct InvalidPrkLength;
 
 /// Structure for InvalidLength, used for output error handling.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -42,28 +47,55 @@ pub struct InvalidLength;
 /// Structure representing the HKDF, capable of HKDF-Expand and HKDF-extract operations.
 #[derive(Clone)]
 pub struct Hkdf<D>
-    where D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
-          D::OutputSize: ArrayLength<u8>,
+where
+    D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
+    D::BlockSize: ArrayLength<u8> + Clone,
+    D::OutputSize: ArrayLength<u8>,
 {
-    pub prk: GenericArray<u8, D::OutputSize>,
+    hmac: Hmac<D>,
 }
 
 impl<D> Hkdf<D>
-    where D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
-          D::BlockSize: ArrayLength<u8> + Clone,
-          D::OutputSize: ArrayLength<u8>,
+where
+    D: Input + BlockInput + FixedOutput + Reset + Default + Clone,
+    D::BlockSize: ArrayLength<u8> + Clone,
+    D::OutputSize: ArrayLength<u8>,
 {
-    /// The RFC5869 HKDF-Extract operation
-    pub fn extract(salt: Option<&[u8]>, ikm: &[u8]) -> Hkdf<D> {
+    /// Convenience method for [`extract`] when the generated pseudorandom key
+    /// can be ignored and only HKDF-Expand operation is needed.
+    pub fn new(salt: Option<&[u8]>, ikm: &[u8]) -> Hkdf<D> {
+        let (_, hkdf) = Hkdf::extract(salt, ikm);
+        hkdf
+    }
+
+    /// Create `Hkdf` from an already cryptographically strong pseudorandom key
+    /// as per section 3.3 from RFC5869.
+    pub fn from_prk(prk: &[u8]) -> Result<Hkdf<D>, InvalidPrkLength> {
+        use generic_array::typenum::Unsigned;
+
+        // section 2.3 specifies that prk must be "at least HashLen octets"
+        if prk.len() < D::OutputSize::to_usize() {
+            return Err(InvalidPrkLength);
+        }
+
+        Ok(Hkdf {
+            hmac: Hmac::new_varkey(prk).expect("HMAC can take a key of any size"),
+        })
+    }
+
+    /// The RFC5869 HKDF-Extract operation returning both the generated
+    /// pseudorandom key and `Hkdf` struct for expanding.
+    pub fn extract(salt: Option<&[u8]>, ikm: &[u8]) -> (GenericArray<u8, D::OutputSize>, Hkdf<D>) {
         let mut hmac = match salt {
             Some(s) => Hmac::<D>::new_varkey(s).expect("HMAC can take a key of any size"),
             None => Hmac::<D>::new(&Default::default()),
         };
 
         hmac.input(ikm);
-        Hkdf {
-            prk: hmac.result().code(),
-        }
+
+        let prk = hmac.result().code();
+        let hkdf = Hkdf::from_prk(&prk).expect("PRK size is correct");
+        (prk, hkdf)
     }
 
     /// The RFC5869 HKDF-Expand operation
@@ -77,11 +109,13 @@ impl<D> Hkdf<D>
             return Err(InvalidLength);
         }
 
-        let mut hmac = Hmac::<D>::new_varkey(&self.prk).unwrap();
+        let mut hmac = self.hmac.clone();
         for (blocknum, okm_block) in okm.chunks_mut(hmac_output_bytes).enumerate() {
             let block_len = okm_block.len();
 
-            if let Some(ref prev) = prev { hmac.input(prev) };
+            if let Some(ref prev) = prev {
+                hmac.input(prev)
+            };
             hmac.input(info);
             hmac.input(&[blocknum as u8 + 1]);
 
@@ -95,8 +129,17 @@ impl<D> Hkdf<D>
     }
 }
 
+impl fmt::Display for InvalidPrkLength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        f.write_str("invalid pseudorandom key length, too short")
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for InvalidPrkLength {}
+
 impl fmt::Display for InvalidLength {
-    fn fmt(&self, f: & mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         f.write_str("invalid number of blocks, too large output")
     }
 }


### PR DESCRIPTION
Add support for HKDF with PRK lengths >= Digest::OutputSize. This is allowed in RFC 5869 (see section 2.3 for `Extend` operation input requirements and section 3.3 WRT using PRKs that were not generated from the `Extract` step). Unfortunately the current API does not support this (since `Hkdf.prk` is a fixed sized array) so breaking changes were required.