### PR TITLE
Fix the Apache copyright, add names

### DIFF
--- a/hkdf/LICENSE-APACHE
+++ b/hkdf/LICENSE-APACHE
@@ -175,18 +175,8 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
+Copyright (c) 2015-2018 Vlad Filippov
+Copyright (c) 2018 RustCrypto Developers
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ref: https://github.com/android/plaid/blob/master/LICENSE#L189

@newpavlov r?

We should fix this elsewhere in RustCrypto crates