### PR TITLE
hkdf: upgrade to pre-release upstream crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
     - env: TARGET=x86_64-unknown-linux-gnu MSRV=true
-      rust: 1.21.0
+      rust: 1.41.0
     - env: TARGET=powerpc-unknown-linux-gnu
       rust: stable
     - env: TARGET=powerpc64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,11 @@
 members = [
     "hkdf",
 ]
+
+[patch.crates-io]
+block-buffer = { git = "https://github.com/RustCrypto/utils" }
+crypto-mac = { git = "https://github.com/RustCrypto/traits" }
+digest = { git = "https://github.com/RustCrypto/traits" }
+hmac = { git = "https://github.com/RustCrypto/MACs" }
+sha-1 = { git = "https://github.com/RustCrypto/hashes" }
+sha2 = { git = "https://github.com/RustCrypto/hashes" }

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -17,14 +17,14 @@ name = "hkdf"
 path = "src/hkdf.rs"
 
 [dependencies]
-digest = "0.8"
-hmac = "0.7.1"
+digest = "= 0.9.0-pre"
+hmac = "= 0.8.0-pre"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"
-hex = "0.3.*"
-sha-1 = "0.8.*"
-sha2 = "0.8.*"
+hex = "0.4.0-pre"
+sha-1 = "0.9.0-pre"
+sha2 = "0.9.0-pre"
 bencher = "0.1"
 
 [[bench]]


### PR DESCRIPTION
Updates the `digest` and `hmac` crates to the new (2018 edition) upstream crates (v0.9.0-pre and v0.8.0-pre respectively).