### PR TITLE
hkdf: 2018 edition upgrade

### DIFF
--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/RustCrypto/KDFs/"
 description = "HMAC-based Extract-and-Expand Key Derivation Function (HKDF)"
 keywords = [ "HKDF", "Crypto" ]
 readme = "README.md"
+edition = "2018"
 
 [features]
 std = []

--- a/hkdf/benches/hkdf.rs
+++ b/hkdf/benches/hkdf.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate bencher;
-extern crate hkdf;
-extern crate sha2;
 
 use bencher::Bencher;
 use hkdf::Hkdf;

--- a/hkdf/examples/extract.rs
+++ b/hkdf/examples/extract.rs
@@ -1,6 +1,4 @@
-extern crate hex;
-extern crate hkdf;
-extern crate sha2;
+use hex;
 
 use hkdf::Hkdf;
 use sha2::Sha256;

--- a/hkdf/examples/extract.rs
+++ b/hkdf/examples/extract.rs
@@ -1,5 +1,3 @@
-use hex;
-
 use hkdf::Hkdf;
 use sha2::Sha256;
 

--- a/hkdf/examples/from_prk.rs
+++ b/hkdf/examples/from_prk.rs
@@ -1,6 +1,4 @@
-extern crate hex;
-extern crate hkdf;
-extern crate sha2;
+use hex;
 
 use hkdf::Hkdf;
 use sha2::Sha256;

--- a/hkdf/examples/from_prk.rs
+++ b/hkdf/examples/from_prk.rs
@@ -1,5 +1,3 @@
-use hex;
-
 use hkdf::Hkdf;
 use sha2::Sha256;
 

--- a/hkdf/examples/main.rs
+++ b/hkdf/examples/main.rs
@@ -1,6 +1,4 @@
-extern crate hex;
-extern crate hkdf;
-extern crate sha2;
+use hex;
 
 use hkdf::Hkdf;
 use sha2::Sha256;

--- a/hkdf/examples/main.rs
+++ b/hkdf/examples/main.rs
@@ -1,5 +1,3 @@
-use hex;
-
 use hkdf::Hkdf;
 use sha2::Sha256;
 

--- a/hkdf/src/hkdf.rs
+++ b/hkdf/src/hkdf.rs
@@ -23,9 +23,9 @@
 //! ```
 //!
 //! [1]: https://tools.ietf.org/html/rfc5869
-#![no_std]
 
-use digest;
+#![no_std]
+#![warn(rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/hkdf/src/hkdf.rs
+++ b/hkdf/src/hkdf.rs
@@ -25,8 +25,8 @@
 //! [1]: https://tools.ietf.org/html/rfc5869
 #![no_std]
 
-extern crate digest;
-extern crate hmac;
+use digest;
+
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -71,7 +71,7 @@ where
     /// Create `Hkdf` from an already cryptographically strong pseudorandom key
     /// as per section 3.3 from RFC5869.
     pub fn from_prk(prk: &[u8]) -> Result<Hkdf<D>, InvalidPrkLength> {
-        use generic_array::typenum::Unsigned;
+        use crate::generic_array::typenum::Unsigned;
 
         // section 2.3 specifies that prk must be "at least HashLen octets"
         if prk.len() < D::OutputSize::to_usize() {
@@ -100,7 +100,7 @@ where
 
     /// The RFC5869 HKDF-Expand operation
     pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), InvalidLength> {
-        use generic_array::typenum::Unsigned;
+        use crate::generic_array::typenum::Unsigned;
 
         let mut prev: Option<GenericArray<u8, <D as digest::FixedOutput>::OutputSize>> = None;
 
@@ -130,7 +130,7 @@ where
 }
 
 impl fmt::Display for InvalidPrkLength {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("invalid pseudorandom key length, too short")
     }
 }
@@ -139,7 +139,7 @@ impl fmt::Display for InvalidPrkLength {
 impl ::std::error::Error for InvalidPrkLength {}
 
 impl fmt::Display for InvalidLength {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.write_str("invalid number of blocks, too large output")
     }
 }

--- a/hkdf/tests/tests.rs
+++ b/hkdf/tests/tests.rs
@@ -1,7 +1,4 @@
-extern crate hex;
-extern crate hkdf;
-extern crate sha1;
-extern crate sha2;
+use hex;
 
 use hkdf::Hkdf;
 use sha1::Sha1;


### PR DESCRIPTION
~~NOTE: this PR includes commits from #31 which should get merged first.~~ Merged!

Updates the codebase to Rust 2018 edition.

Performed mostly automatically using `cargo fix --edition` and `cargo fix --edition-idioms`.