### PR TITLE
hkdf: upgrade to `digest` v0.9; `hmac` v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,3 @@
 members = [
     "hkdf",
 ]
-
-[patch.crates-io]
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-crypto-mac = { git = "https://github.com/RustCrypto/traits" }
-digest = { git = "https://github.com/RustCrypto/traits" }
-hmac = { git = "https://github.com/RustCrypto/MACs" }
-sha-1 = { git = "https://github.com/RustCrypto/hashes" }
-sha2 = { git = "https://github.com/RustCrypto/hashes" }

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -18,14 +18,14 @@ name = "hkdf"
 path = "src/hkdf.rs"
 
 [dependencies]
-digest = "= 0.9.0-pre"
-hmac = "= 0.8.0-pre"
+digest = "0.9"
+hmac = "0.8"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"
-hex = "0.4.0-pre"
-sha-1 = "0.9.0-pre"
-sha2 = "0.9.0-pre"
+hex = "0.4"
+sha-1 = "0.9"
+sha2 = "0.9"
 bencher = "0.1"
 
 [[bench]]

--- a/hkdf/src/hkdf.rs
+++ b/hkdf/src/hkdf.rs
@@ -93,7 +93,7 @@ where
 
         hmac.update(ikm);
 
-        let prk = hmac.result().into_bytes();
+        let prk = hmac.finalize().into_bytes();
         let hkdf = Hkdf::from_prk(&prk).expect("PRK size is correct");
         (prk, hkdf)
     }
@@ -119,7 +119,7 @@ where
             hmac.update(info);
             hmac.update(&[blocknum as u8 + 1]);
 
-            let output = hmac.result_reset().into_bytes();
+            let output = hmac.finalize_reset().into_bytes();
             okm_block.copy_from_slice(&output[..block_len]);
 
             prev = Some(output);


### PR DESCRIPTION
Removes the prerelease dependencies and replaces them with the final crate releases.

One small API change had occurred (`result` -> `finalize`)