### PR TITLE
hkdf v0.9.0-alpha.0

### DIFF
--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.8.1-alpha.0"
+version = "0.9.0-alpha.0"
 authors = ["vladikoff", "warner", "RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"


### PR DESCRIPTION
We're trying to complete RustCrypto upgrades against some of our projects which use the new releases of things like `digest` and `hmac` and this is one of the crates we're blocked on (for crates we'd like to publish ASAP as it were, so we can't rely on a git dependency).

I'm not sure what additional work you'd like to do before a final release (e.g. landing #34), but hopefully it's OK to cut an alpha release with the upgrades in the interim?