### PR TITLE
Bump `hmac` dependency to v0.10

### DIFF
--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/hkdf.rs"
 
 [dependencies]
 digest = "0.9"
-hmac = "0.8"
+hmac = "0.10"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"


### PR DESCRIPTION
There shouldn't be any changes that actually impact `hkdf`.

This version uses a newer `crypto-mac` release which has a new optional `cipher` feature that uses the new `cipher` crate.