### PR TITLE
README.md(s): update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# RustCrypto KDFs [![Build Status](https://travis-ci.org/RustCrypto/KDFs.svg?branch=master)](https://travis-ci.org/RustCrypto/KDFs)
+# RustCrypto KDFs ![Rust Version][rustc-image] [![Project Chat][chat-image]][chat-link]
 
 Collection of key derivation functions (KDFs) written in pure Rust.
+
+## Crates
+
+| Name   | Algorithm | Crates.io     | Documentation | Build Status |
+|--------|-----------|---------------|---------------|--------------|
+| `hkdf` | [HKDF]    | [![crates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf) | [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf) | [![Build](https://github.com/RustCrypto/KDFs/workflows/hkdf/badge.svg?branch=master&event=push)](https://github.com/RustCrypto/KDFs/actions?query=workflow:hkdf+branch:master)
 
 ## License
 
@@ -16,3 +22,13 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
+
+[//]: # (algorithms)
+
+[HKDF]: https://en.wikipedia.org/wiki/HKDF

--- a/hkdf/README.md
+++ b/hkdf/README.md
@@ -1,4 +1,11 @@
-# rust-hkdf [![creates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf) [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf)
+# RustCrypto: HKDF
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+[![Build Status][build-image]][build-link]
 
 [HMAC-based Extract-and-Expand Key Derivation Function (HKDF)](https://tools.ietf.org/html/rfc5869) for [Rust](http://www.rust-lang.org/).
 
@@ -34,3 +41,16 @@ See the example [examples/main.rs](examples/main.rs) or run it with `cargo run -
 [![Vlad Filippov](https://avatars3.githubusercontent.com/u/128755?s=70)](http://vf.io/) | [![Brian Warner](https://avatars3.githubusercontent.com/u/27146?v=4&s=70)](http://www.lothar.com/blog/) 
 ---|---
 [Vlad Filippov](http://vf.io/) | [Brian Warner](http://www.lothar.com/blog/)
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/hkdf.svg
+[crate-link]: https://crates.io/crates/hkdf
+[docs-image]: https://docs.rs/hkdf/badge.svg
+[docs-link]: https://docs.rs/hkdf/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
+[build-image]: https://github.com/RustCrypto/KDFs/workflows/hkdf/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/KDFs/actions?query=workflow:hkdf


### PR DESCRIPTION
Adds the standard set of README.md badges that the other RustCrypto projects use.