### PR TITLE
hkdf v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hkdf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bencher",
  "blobby",

--- a/hkdf/CHANGELOG.md
+++ b/hkdf/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.11.0 (2021-04-29)
+### Added
+- Wycheproof HKDF test vectors ([#49])
+
+### Changed
+- Bump `hmac` crate dependency to v0.11 ([#50])
+
+### Fixed
+- HKDF-Extract with empty salt ([#46])
+
+[#46]: https://github.com/RustCrypto/KDFs/pull/46
+[#49]: https://github.com/RustCrypto/KDFs/pull/49
+[#50]: https://github.com/RustCrypto/KDFs/pull/50
+
+## 0.10.0 (2020-10-26)
+### Changed
+- Bump `hmac` dependency to v0.10 ([#40])
+
+[#40]: https://github.com/RustCrypto/KDFs/pull/40
+
+## 0.9.0 (2020-06-22)
+### Added
+- Multipart features for HKDF-Extract and HKDF-Expand ([#34])
+
+### Changed
+- Bump `digest` v0.9; `hmac` v0.9 ([#35])
+
+[#34]: https://github.com/RustCrypto/KDFs/pull/34
+[#35]: https://github.com/RustCrypto/KDFs/pull/35
+
+## 0.8.0 (2019-07-26)
+### Added
+- `Hkdf::from_prk()`, `Hkdf::extract()`
+
+## 0.7.1 (2019-07-15)
+
+## 0.7.0 (2018-10-16)
+### Changed
+- Update digest to 0.8 
+- Refactor for API changes
+
+### Removed  
+- Redundant `generic-array` crate.
+
+## 0.6.0 (2018-08-20)
+### Changed
+- The `expand` signature has changed.
+  
+### Removed
+- `std` requirement 
+
+## 0.5.0 (2018-05-20)
+### Fixed
+- Omitting HKDF salt.
+
+### Removed
+- Deprecated interface
+
+## 0.4.0 (2018-03-20
+### Added
+- Benchmarks
+- derive `Clone`
+
+### Changed
+- RFC-inspired interface 
+- Reduce heap allocation
+- Bump deps: hex-0.3
+
+### Removed
+- Unnecessary mut
+
+## 0.3.0 (2017-11-29)
+### Changed
+- update dependencies: digest-0.7, hmac-0.5
+
+## 0.2.0 (2017-09-21)
+### Fixed
+- Support for rustc 1.20.0
+
+## 0.1.2 (2017-09-21)
+### Fixed
+- Support for rustc 1.5.0
+
+## 0.1.0 (2017-09-21)
+- Initial release

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["vladikoff", "warner", "RustCrypto Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"

--- a/hkdf/README.md
+++ b/hkdf/README.md
@@ -24,18 +24,6 @@ hkdf = "0.7"
 
 See the example [examples/main.rs](examples/main.rs) or run it with `cargo run --example main`
 
-## Changelog
-
-- 0.8.0 - new API, add `Hkdf::from_prk()`, `Hkdf::extract()`
-- 0.7.0 - Update digest to 0.8, refactor for API changes, remove redundant `generic-array` crate.
-- 0.6.0 - remove std requirement. The `expand` signature has changed.
-- 0.5.0 - removed deprecated interface, fixed omitting HKDF salt.
-- 0.4.0 - RFC-inspired interface, Reduce heap allocation, remove unnecessary mut, derive Clone. deps: hex-0.3, benchmarks.
-- 0.3.0 - update dependencies: digest-0.7, hmac-0.5
-- 0.2.0 - support for rustc 1.20.0
-- 0.1.1 - fixes to support rustc 1.5.0
-- 0.1.0 - initial release
-
 ## Authors
 
 [![Vlad Filippov](https://avatars3.githubusercontent.com/u/128755?s=70)](http://vf.io/) | [![Brian Warner](https://avatars3.githubusercontent.com/u/27146?v=4&s=70)](http://www.lothar.com/blog/) 


### PR DESCRIPTION
### Added
- Wycheproof HKDF test vectors ([#49])

### Changed
- Bump `hmac` crate dependency to v0.11 ([#50])

### Fixed
- HKDF-Extract with empty salt ([#46])

[#46]: https://github.com/RustCrypto/KDFs/pull/46
[#49]: https://github.com/RustCrypto/KDFs/pull/49
[#50]: https://github.com/RustCrypto/KDFs/pull/50