### PR TITLE
Add ability to switch HMAC implementation to SimpleHmac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,18 +34,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "blobby",
  "hex-literal",
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.109"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
+checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
 
 [[package]]
 name = "proc-macro-hack"
@@ -144,12 +144,12 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/hkdf/CHANGELOG.md
+++ b/hkdf/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (2022-01-27)
+### Added
+- Ability to switch HMAC implementation to `SimpleHmac` ([#57])
+
+[#57]: https://github.com/RustCrypto/KDFs/pull/55
+
 ## 0.12.0 (2021-12-07)
 ### Changed
 - Bump `hmac` crate dependency to v0.12 and `digest` to v0.10 ([#52])

--- a/hkdf/CHANGELOG.md
+++ b/hkdf/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.12.1 (2022-01-27)
 ### Added
-- Ability to switch HMAC implementation to `SimpleHmac` ([#57])
+- Ability to switch HMAC implementation to `SimpleHmac` with respective `SimpleHkdfExtract` and `SimpleHkdf` aliases ([#57])
 
 [#57]: https://github.com/RustCrypto/KDFs/pull/55
 

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.12.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.1" # Also update html_root_url in lib.rs when bumping this
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"

--- a/hkdf/src/errors.rs
+++ b/hkdf/src/errors.rs
@@ -1,0 +1,29 @@
+use core::fmt;
+
+/// Error that is returned when supplied pseudorandom key (PRK) is not long enough.
+#[derive(Copy, Clone, Debug)]
+pub struct InvalidPrkLength;
+
+impl fmt::Display for InvalidPrkLength {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("invalid pseudorandom key length, too short")
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl ::std::error::Error for InvalidPrkLength {}
+
+/// Structure for InvalidLength, used for output error handling.
+#[derive(Copy, Clone, Debug)]
+pub struct InvalidLength;
+
+impl fmt::Display for InvalidLength {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("invalid number of blocks, too large output")
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl ::std::error::Error for InvalidLength {}

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -99,12 +99,19 @@ use core::marker::PhantomData;
 use hmac::digest::{
     crypto_common::AlgorithmName, generic_array::typenum::Unsigned, Output, OutputSizeUser,
 };
-use hmac::Hmac;
+use hmac::{Hmac, SimpleHmac};
 
 mod errors;
 mod sealed;
 
 use errors::{InvalidLength, InvalidPrkLength};
+
+/// [`HkdfExtract`] variant which uses [`SimpleHmac`] for underlying HMAC
+/// implementation.
+pub type SimpleHkdfExtract<H> = HkdfExtract<H, SimpleHmac<H>>;
+/// [`Hkdf`] variant which uses [`SimpleHmac`] for underlying HMAC
+/// implementation.
+pub type SimpleHkdf<H> = Hkdf<H, SimpleHmac<H>>;
 
 /// Structure representing the streaming context of an HKDF-Extract operation
 /// ```rust
@@ -267,7 +274,7 @@ where
     }
 }
 
-/// Sealed trait implemented for [`Hmac`] and [`SimpleHmac`][hmac::SimpleHmac].
+/// Sealed trait implemented for [`Hmac`] and [`SimpleHmac`].
 pub trait HmacImpl<H: OutputSizeUser>: sealed::Sealed<H> {}
 
 impl<H: OutputSizeUser, T: sealed::Sealed<H>> HmacImpl<H> for T {}

--- a/hkdf/src/sealed.rs
+++ b/hkdf/src/sealed.rs
@@ -1,0 +1,97 @@
+use hmac::digest::{
+    block_buffer::Eager,
+    core_api::{
+        BlockSizeUser, BufferKindUser, CoreProxy, CoreWrapper, FixedOutputCore, OutputSizeUser,
+        UpdateCore,
+    },
+    generic_array::typenum::{IsLess, Le, NonZero, U256},
+    Digest, FixedOutput, HashMarker, KeyInit, Output, Update,
+};
+use hmac::{Hmac, HmacCore, SimpleHmac};
+
+pub trait Sealed<H: OutputSizeUser> {
+    type Core: Clone;
+
+    fn new_from_slice(key: &[u8]) -> Self;
+
+    fn new_core(key: &[u8]) -> Self::Core;
+
+    fn from_core(core: &Self::Core) -> Self;
+
+    fn update(&mut self, data: &[u8]);
+
+    fn finalize(self) -> Output<H>;
+}
+
+impl<H> Sealed<H> for Hmac<H>
+where
+    H: CoreProxy + OutputSizeUser,
+    H::Core: HashMarker
+        + UpdateCore
+        + FixedOutputCore
+        + BufferKindUser<BufferKind = Eager>
+        + Default
+        + Clone,
+    <H::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<H::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+    type Core = HmacCore<H>;
+
+    #[inline(always)]
+    fn new_from_slice(key: &[u8]) -> Self {
+        KeyInit::new_from_slice(key).expect("HMAC can take a key of any size")
+    }
+
+    #[inline(always)]
+    fn new_core(key: &[u8]) -> Self::Core {
+        HmacCore::new_from_slice(key).expect("HMAC can take a key of any size")
+    }
+
+    #[inline(always)]
+    fn from_core(core: &Self::Core) -> Self {
+        CoreWrapper::from_core(core.clone())
+    }
+
+    #[inline(always)]
+    fn update(&mut self, data: &[u8]) {
+        Update::update(self, data);
+    }
+
+    #[inline(always)]
+    fn finalize(self) -> Output<H> {
+        // Output<H> and Output<H::Core> are always equal to each other,
+        // but we can not prove it at type level
+        Output::<H>::clone_from_slice(&self.finalize_fixed())
+    }
+}
+
+impl<H: Digest + BlockSizeUser + Clone> Sealed<H> for SimpleHmac<H> {
+    type Core = Self;
+
+    #[inline(always)]
+    fn new_from_slice(key: &[u8]) -> Self {
+        KeyInit::new_from_slice(key).expect("HMAC can take a key of any size")
+    }
+
+    #[inline(always)]
+    fn new_core(key: &[u8]) -> Self::Core {
+        KeyInit::new_from_slice(key).expect("HMAC can take a key of any size")
+    }
+
+    #[inline(always)]
+    fn from_core(core: &Self::Core) -> Self {
+        core.clone()
+    }
+
+    #[inline(always)]
+    fn update(&mut self, data: &[u8]) {
+        Update::update(self, data);
+    }
+
+    #[inline(always)]
+    fn finalize(self) -> Output<H> {
+        // Output<H> and Output<H::Core> are always equal to each other,
+        // but we can not prove it at type level
+        Output::<H>::clone_from_slice(&self.finalize_fixed())
+    }
+}


### PR DESCRIPTION
Allows HKDF to be used with hash functions like BLAKE2/3. The API should be completely backwards compatible.

Closes #54 

cc @jbis9051