### PR TITLE
Re-export error types

### DIFF
--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -104,7 +104,7 @@ use hmac::{Hmac, SimpleHmac};
 mod errors;
 mod sealed;
 
-use errors::{InvalidLength, InvalidPrkLength};
+pub use errors::{InvalidLength, InvalidPrkLength};
 
 /// [`HkdfExtract`] variant which uses [`SimpleHmac`] for underlying HMAC
 /// implementation.


### PR DESCRIPTION
These were dropped in #57 