### PR TITLE
hkdf: switch from `sha-1` to `sha1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "blobby",
  "hex-literal 0.2.2",
  "hmac",
- "sha-1",
+ "sha1",
  "sha2",
 ]
 
@@ -130,10 +130,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -17,7 +17,7 @@ hmac = "0.12.1"
 [dev-dependencies]
 blobby = "0.3"
 hex-literal = "0.2.2"
-sha-1 = { version = "0.10", default-features = false }
+sha1 = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 
 [features]


### PR DESCRIPTION
As a `dev-dependency`. The former is deprecated.