### PR TITLE
Add salt recommendation for HKDF docs

### DIFF
--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -7,8 +7,11 @@
 //! into some Output Key Material (OKM) bound to an "info" context string.
 //!
 //! There are two usage options for the salt:
+//!
 //! - [`None`] or static for domain separation in a private setting
 //! -  guaranteed to be uniformly-distributed and unique in a public setting
+//!
+//! Other non fitting data should be added to the `IKM` or `info`.
 //!
 //! ```rust
 //! use sha2::Sha256;

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -6,6 +6,10 @@
 //! Material (IKM) and an optional salt, then you expand it (perhaps multiple times)
 //! into some Output Key Material (OKM) bound to an "info" context string.
 //!
+//! There are two usage options for the salt:
+//! - [`None`] or static for domain separation in a private setting
+//! -  guaranteed to be uniformly-distributed and unique in a public setting
+//!
 //! ```rust
 //! use sha2::Sha256;
 //! use hkdf::Hkdf;

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -184,6 +184,8 @@ where
 }
 
 /// Structure representing the HKDF, capable of HKDF-Expand and HKDF-Extract operations.
+/// Recommendations for the correct usage of the parameters can be found in the
+/// [crate root](index.html#usage).
 #[derive(Clone)]
 pub struct Hkdf<H: OutputSizeUser, I: HmacImpl<H> = Hmac<H>> {
     hmac: I::Core,


### PR DESCRIPTION
It is easy to misuse the HKDF `salt` parameter like I've probably found such a weakness in a project depending on this crate (https://github.com/cryptoballot/cryptoballot/issues/17). Therefore it should be a good idea to document how to use the parameters correctly.

I am not 100 percent sure, but I believe I have correctly summarized the information from the following three, at first seemingly contradictory, blog posts.

## [Soatok](https://soatok.blog/2021/11/17/understanding-hkdf/#how-hkdf-salts-are-misused)

Which means: You’re not supposed to use HKDF with a constant IKM, info label, etc. but vary the salt for multiple invocations. The salt must either be a fixed random value, or NULL.
HKDF uses salts as a mechanism to improve the quality of randomness when working with group elements and passwords.
How Should You Introduce Randomness into HKDF? Just shove it in the info parameter.
It may seem weird, and defy intuition, but the correct way to introduce randomness into HKDF as most developers interact with the algorithm is to skip the salt parameter entirely (either fixing it to a specific value for domain-separation or leaving it NULL), and instead concatenate data into the info parameter.

## [Filippo](https://words.filippo.io/dispatches/post-quantum-age/#the-age-kyber768x25519-plugin)

Native X25519 recipients wrap the file key using ChaCha20Poly1305 with a key derived as `HKDF-SHA-256(ikm = shared secret, salt = ephemeral share || recipient, info = "age-encryption.org/v1/X25519")`. We could just add the Kyber key to the input key material, but we can take the occasion to fix a small regret in the age design: the salt is supposed to be random or fixed for domain separation, while ephemeral share and recipient should have been part of the input key material. [...]

The wrapping key for the Kyber768+X25519 plugin can then be `HKDF-SHA-256(ikm = shared secret || ephemeral share || recipient || kyber key, salt = "age-encryption.org/Kyber768+X25519", info = nil)`.

## [Cendyne](https://cendyne.dev/posts/2023-01-30-how-to-use-hkdf.html#HKDF-misuse)

Here are a few ways HKDF can be misused:

- In a public setting, no salt is given.
- The salt input is not indistinguishable from random (IND).
- The salt input is used for domain separation.
- The same salt is used across multiple transactions in a public setting.
- Different salts are used in a private setting.
- The inputs to HKDFs are the same for different contexts, resulting in the same keys for different purposes.