### PR TITLE
hkdf: fix `Debug` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "blobby",
  "hex-literal 0.2.2",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "proc-macro-hack"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.12.3" # Also update html_root_url in lib.rs when bumping this
+version = "0.12.4"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -89,8 +89,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/hkdf/0.12.3"
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
@@ -173,12 +172,13 @@ where
 
 impl<H, I> fmt::Debug for HkdfExtract<H, I>
 where
-    H: OutputSizeUser + AlgorithmName,
+    H: OutputSizeUser,
     I: HmacImpl<H>,
+    I::Core: AlgorithmName,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("HkdfExtract<")?;
-        <H as AlgorithmName>::write_alg_name(f)?;
+        <I::Core as AlgorithmName>::write_alg_name(f)?;
         f.write_str("> { ... }")
     }
 }
@@ -273,12 +273,13 @@ impl<H: OutputSizeUser, I: HmacImpl<H>> Hkdf<H, I> {
 
 impl<H, I> fmt::Debug for Hkdf<H, I>
 where
-    H: OutputSizeUser + AlgorithmName,
+    H: OutputSizeUser,
     I: HmacImpl<H>,
+    I::Core: AlgorithmName,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Hkdf<")?;
-        <H as AlgorithmName>::write_alg_name(f)?;
+        <I::Core as AlgorithmName>::write_alg_name(f)?;
         f.write_str("> { ... }")
     }
 }

--- a/hkdf/tests/tests.rs
+++ b/hkdf/tests/tests.rs
@@ -446,3 +446,10 @@ new_test!(
     "wycheproof-sha512",
     SimpleHkdf::<Sha512>
 );
+
+#[test]
+fn test_debug_impls() {
+    fn needs_debug<T: std::fmt::Debug>() {}
+    needs_debug::<Hkdf<Sha256>>();
+    needs_debug::<HkdfExtract<Sha256>>();
+}


### PR DESCRIPTION
Closes #89 

Right now `Debug` will not be implemented for `SimpleHkdf` since we currently do not implement `AlgorithmName` for `SimpleHmac`.