### PR TITLE
Bump `digest` to v0.11.0-pre.3; MSRV 1.71

### DIFF
--- a/.github/workflows/concat-kdf.yml
+++ b/.github/workflows/concat-kdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hkdf.yml
+++ b/.github/workflows/hkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,6 +37,8 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
+    # Temporarily disabled until hkdf 0.13.0-pre.0 gets published
+    if: false
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
@@ -46,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.71.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,11 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
 dependencies = [
- "generic-array",
+ "crypto-common",
 ]
 
 [[package]]
@@ -25,10 +25,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "concat-kdf"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "digest",
- "hex-literal 0.3.4",
+ "hex-literal",
  "sha2",
 ]
 
@@ -43,19 +43,20 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -63,46 +64,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getrandom"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "typenum",
- "version_check",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "hex-literal"
-version = "0.2.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70693199b3cf4552f3fa720b54163927a3ebed2aef240efaf556033ab336a11"
-dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hex-literal-impl"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59448fc2f82a5fb6907f78c3d69d843e82ff5b051923313cc4438cb0c7b745a8"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0-pre"
 dependencies = [
  "blobby",
- "hex-literal 0.2.2",
+ "hex-literal",
  "hmac",
  "sha1",
  "sha2",
@@ -110,11 +93,20 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "e22cb0183a745c3444af57c24aa1293e1f3e538717acce39a9d3b271c999b24f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -124,16 +116,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+name = "rand_core"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "c14486028be4486a46aa8c4131ef865ec85b221c1e1327af76f10b6981e06850"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -142,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -164,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "hkdf",
     "concat-kdf",

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "concat-kdf"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Concatenation Key Derivation Function (Concat KDF)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/concat-kdf"
 repository = "https://github.com/RustCrypto/KDFs"
 keywords = ["crypto", "concat-kdf", "KDF", "NIST"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.71"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-hex-literal = "0.3.4"
-sha2 = { version = "0.10.3", default-features = false }
+hex-literal = "0.4"
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
 
 [features]
 std = []

--- a/concat-kdf/README.md
+++ b/concat-kdf/README.md
@@ -21,12 +21,39 @@ let mut key = [0u8; 32];
 concat_kdf::derive_key_into::<sha2::Sha256>(b"shared-secret", b"other-info", &mut key).unwrap();
 ```
 
+## Minimum Supported Rust Version
+
+Rust **1.71** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
 [crate-image]: https://img.shields.io/crates/v/concat-kdf.svg
 [crate-link]: https://crates.io/crates/concat-kdf
 [docs-image]: https://docs.rs/concat-kdf/badge.svg
 [docs-link]: https://docs.rs/concat-kdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
 [build-image]: https://github.com/RustCrypto/KDFs/workflows/concat-kdf/badge.svg?branch=master&event=push

--- a/concat-kdf/src/lib.rs
+++ b/concat-kdf/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use core::fmt;
-use digest::{generic_array::typenum::Unsigned, Digest, FixedOutputReset, Update};
+use digest::{array::typenum::Unsigned, Digest, FixedOutputReset, Update};
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0-pre"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"
@@ -9,16 +9,17 @@ description = "HMAC-based Extract-and-Expand Key Derivation Function (HKDF)"
 keywords = ["crypto", "HKDF", "KDF"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.71"
 
 [dependencies]
-hmac = "0.12.1"
+hmac = "=0.13.0-pre.0"
 
 [dev-dependencies]
 blobby = "0.3"
-hex-literal = "0.2.2"
-sha1 = { version = "0.10", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+hex-literal = "0.4"
+sha1 = { version = "=0.11.0-pre.0", default-features = false }
+sha2 = { version = "=0.11.0-pre.0", default-features = false }
 
 [features]
 std = ["hmac/std"]

--- a/hkdf/README.md
+++ b/hkdf/README.md
@@ -71,6 +71,33 @@ let expected = hex!("
 assert_eq!(okm, expected);
 ```
 
+## Minimum Supported Rust Version
+
+Rust **1.71** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+
+## License
+
+Licensed under either of:
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
 [//]: # (badges)
 
 [crate-image]: https://img.shields.io/crates/v/hkdf.svg
@@ -78,7 +105,7 @@ assert_eq!(okm, expected);
 [docs-image]: https://docs.rs/hkdf/badge.svg
 [docs-link]: https://docs.rs/hkdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
 [build-image]: https://github.com/RustCrypto/KDFs/workflows/hkdf/badge.svg?branch=master&event=push

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -103,7 +103,7 @@ pub use hmac;
 use core::fmt;
 use core::marker::PhantomData;
 use hmac::digest::{
-    crypto_common::AlgorithmName, generic_array::typenum::Unsigned, Output, OutputSizeUser,
+    array::typenum::Unsigned, crypto_common::AlgorithmName, Output, OutputSizeUser,
 };
 use hmac::{Hmac, SimpleHmac};
 

--- a/hkdf/src/sealed.rs
+++ b/hkdf/src/sealed.rs
@@ -1,13 +1,8 @@
 use hmac::digest::{
-    block_buffer::Eager,
-    core_api::{
-        BlockSizeUser, BufferKindUser, CoreProxy, CoreWrapper, FixedOutputCore, OutputSizeUser,
-        UpdateCore,
-    },
-    generic_array::typenum::{IsLess, Le, NonZero, U256},
-    Digest, FixedOutput, HashMarker, KeyInit, Output, Update,
+    core_api::{BlockSizeUser, CoreWrapper, OutputSizeUser},
+    Digest, FixedOutput, KeyInit, Output, Update,
 };
-use hmac::{Hmac, HmacCore, SimpleHmac};
+use hmac::{EagerHash, Hmac, HmacCore, SimpleHmac};
 
 pub trait Sealed<H: OutputSizeUser> {
     type Core: Clone;
@@ -25,15 +20,7 @@ pub trait Sealed<H: OutputSizeUser> {
 
 impl<H> Sealed<H> for Hmac<H>
 where
-    H: CoreProxy + OutputSizeUser,
-    H::Core: HashMarker
-        + UpdateCore
-        + FixedOutputCore
-        + BufferKindUser<BufferKind = Eager>
-        + Default
-        + Clone,
-    <H::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-    Le<<H::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+    H: EagerHash + OutputSizeUser,
 {
     type Core = HmacCore<H>;
 


### PR DESCRIPTION
For `hkdf`, this upgrades `hmac` to v0.13.0-pre, which transitively depends on `digest` v0.11.0-pre.3.

This notably includes the migration from `generic-array` to `hybrid-array`.

Also bumps edition to 2021, and `hex-literal` to v0.4.

Depends on https://github.com/RustCrypto/MACs/pull/150 which needs to be merged first.