### PR TITLE
hkdf: bump `hmac` dependency to v0.13.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
+checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
 dependencies = [
  "crypto-common",
 ]
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
+checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
+checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -93,18 +93,18 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22cb0183a745c3444af57c24aa1293e1f3e538717acce39a9d3b271c999b24f"
+checksum = "1ad9bdb2c4daa57033321e5e64c7a8cab02086ee130f8702f72b5c164893026a"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.8"
+version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
+checksum = "b8c5517ac29f08e88170b9647d85cc5f21c2596de177b4867232e20b214b8da1"
 dependencies = [
  "typenum",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14486028be4486a46aa8c4131ef865ec85b221c1e1327af76f10b6981e06850"
+checksum = "731912b869ff1fb4c6432ad4737a5951d5388fbdda0417163a29638206935fe6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0628cd6fd8219612c2d71ad52ab8c2014a18cbdbedbde17de04d400df65997"
+checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre.3"
+digest = "=0.11.0-pre.4"
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.0", default-features = false }
+sha2 = { version = "=0.11.0-pre.1", default-features = false }
 
 [features]
 std = []

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.1"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"
@@ -13,13 +13,13 @@ edition = "2021"
 rust-version = "1.71"
 
 [dependencies]
-hmac = "=0.13.0-pre.0"
+hmac = "=0.13.0-pre.1"
 
 [dev-dependencies]
 blobby = "0.3"
 hex-literal = "0.4"
-sha1 = { version = "=0.11.0-pre.0", default-features = false }
-sha2 = { version = "=0.11.0-pre.0", default-features = false }
+sha1 = { version = "=0.11.0-pre.1", default-features = false }
+sha2 = { version = "=0.11.0-pre.1", default-features = false }
 
 [features]
 std = ["hmac/std"]


### PR DESCRIPTION
Also cuts an `hkdf` v0.13.0-pre.1 release