### PR TITLE
Bump `digest` dependency to v0.11.0-pre.7; MSRV 1.72

### DIFF
--- a/.github/workflows/concat-kdf.yml
+++ b/.github/workflows/concat-kdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hkdf.yml
+++ b/.github/workflows/hkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0
+          toolchain: 1.75.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.4"
+version = "0.11.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b429fb535b92bad18c86f1d7ee7584a175c2810800c7ac5b75b9408b13981979"
+checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -82,7 +82,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-pre.0"
+version = "0.13.0-pre.2"
 dependencies = [
  "blobby",
  "hex-literal",
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.1"
+version = "0.13.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9bdb2c4daa57033321e5e64c7a8cab02086ee130f8702f72b5c164893026a"
+checksum = "1fac01891f12d968a2737928c9af2532abdc750e56a890fdbcafdfff17017678"
 dependencies = [
  "digest",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731912b869ff1fb4c6432ad4737a5951d5388fbdda0417163a29638206935fe6"
+checksum = "301ed48dd873557d86a1843ebcdd511b628f13ec5401a0efa7007dc5a595eb1f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.1"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9daa731ca112bb569b34b41775363a461422813d8ed1ea6dba352eb58ec4e684"
+checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Collection of [Key Derivation Functions][KDF] (KDF) written in pure Rust.
 
 | Algorithm    | Crate          |                                              Crates.io                                              |                                    Documentation                                     |          MSRV           |
 |--------------|----------------|:---------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------:|:-----------------------:|
-| [HKDF]       | [`hkdf`]       |       [![crates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf)       |       [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf)       | ![MSRV 1.41][msrv-1.41] |
-| [Concat-KDF] | [`concat-kdf`] | [![crates.io](https://img.shields.io/crates/v/concat-kdf.svg)](https://crates.io/crates/concat-kdf) | [![Documentation](https://docs.rs/concat-kdf/badge.svg)](https://docs.rs/concat-kdf) | ![MSRV 1.56][msrv-1.56] |
+| [HKDF]       | [`hkdf`]       |       [![crates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf)       |       [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf)       | ![MSRV 1.41][msrv-1.72] |
+| [Concat-KDF] | [`concat-kdf`] | [![crates.io](https://img.shields.io/crates/v/concat-kdf.svg)](https://crates.io/crates/concat-kdf) | [![Documentation](https://docs.rs/concat-kdf/badge.svg)](https://docs.rs/concat-kdf) | ![MSRV 1.56][msrv-1.72] |
 
 *NOTE: for password-based KDFs (e.g. Argon2, PBKDF2, scrypt), please see [RustCrypto/password-hashes]*
 
@@ -37,8 +37,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [deps-image]: https://deps.rs/repo/github/RustCrypto/KDFs/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/KDFs
-[msrv-1.41]: https://img.shields.io/badge/rustc-1.41+-blue.svg
-[msrv-1.56]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[msrv-1.72]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 
 [//]: # (crates)
 

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -10,14 +10,14 @@ documentation = "https://docs.rs/concat-kdf"
 repository = "https://github.com/RustCrypto/KDFs"
 keywords = ["crypto", "concat-kdf", "KDF", "NIST"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
-digest = "=0.11.0-pre.4"
+digest = "=0.11.0-pre.7"
 
 [dev-dependencies]
 hex-literal = "0.4"
-sha2 = { version = "=0.11.0-pre.1", default-features = false }
+sha2 = { version = "=0.11.0-pre.2", default-features = false }
 
 [features]
 std = []

--- a/concat-kdf/README.md
+++ b/concat-kdf/README.md
@@ -23,7 +23,7 @@ concat_kdf::derive_key_into::<sha2::Sha256>(b"shared-secret", b"other-info", &mu
 
 ## Minimum Supported Rust Version
 
-Rust **1.71** or higher.
+Rust **1.72** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -53,7 +53,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/concat-kdf/badge.svg
 [docs-link]: https://docs.rs/concat-kdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
 [build-image]: https://github.com/RustCrypto/KDFs/workflows/concat-kdf/badge.svg?branch=master&event=push

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.13.0-pre.1"
+version = "0.13.0-pre.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"
@@ -10,16 +10,16 @@ keywords = ["crypto", "HKDF", "KDF"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
-hmac = "=0.13.0-pre.1"
+hmac = "=0.13.0-pre.2"
 
 [dev-dependencies]
 blobby = "0.3"
 hex-literal = "0.4"
-sha1 = { version = "=0.11.0-pre.1", default-features = false }
-sha2 = { version = "=0.11.0-pre.1", default-features = false }
+sha1 = { version = "=0.11.0-pre.2", default-features = false }
+sha2 = { version = "=0.11.0-pre.2", default-features = false }
 
 [features]
 std = ["hmac/std"]

--- a/hkdf/README.md
+++ b/hkdf/README.md
@@ -73,7 +73,7 @@ assert_eq!(okm, expected);
 
 ## Minimum Supported Rust Version
 
-Rust **1.71** or higher.
+Rust **1.72** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -105,7 +105,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/hkdf/badge.svg
 [docs-link]: https://docs.rs/hkdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
 [build-image]: https://github.com/RustCrypto/KDFs/workflows/hkdf/badge.svg?branch=master&event=push


### PR DESCRIPTION
Also bumps `hmac` to v0.13.0-pre.2, and cuts an `hkdf` v0.13.0-pre.2 prerelease.