### PR TITLE
hkdf: automatically switch between `Hmac` and `SimpleHmac`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "blake2"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb6b33ba68af672bcef0f6d1cceeeaf36e4143cd1456cafafda5d7f12d91f14"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blobby"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -65,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -84,6 +93,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 name = "hkdf"
 version = "0.13.0-pre.3"
 dependencies = [
+ "blake2",
  "blobby",
  "hex-literal",
  "hmac",
@@ -102,18 +112,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e63b66aee2df5599ba69b17a48113dfc68d2e143ea387ef836509e433bbd7e"
+checksum = "53668f5da5a41d9eaf4bf7064be46d1ebe6a4e1ceed817f387587b18f2b51047"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "rand_core"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -20,6 +20,7 @@ blobby = "0.3"
 hex-literal = "0.4"
 sha1 = { version = "=0.11.0-pre.3", default-features = false }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
+blake2 = { version = "=0.11.0-pre.3", default-features = false }
 
 [features]
 std = ["hmac/std"]

--- a/hkdf/tests/rfc5869.rs
+++ b/hkdf/tests/rfc5869.rs
@@ -1,0 +1,182 @@
+use hex_literal::hex;
+use hkdf::{Hkdf, HmacHash};
+use sha1::Sha1;
+use sha2::Sha256;
+
+struct Test<'a> {
+    ikm: &'a [u8],
+    salt: &'a [u8],
+    info: &'a [u8],
+    prk: &'a [u8],
+    okm: &'a [u8],
+}
+
+fn rfc_test<H: HmacHash>(tests: &[Test]) {
+    let mut buf = [0u8; 128];
+    for test in tests.iter() {
+        let salt = if test.salt.is_empty() {
+            None
+        } else {
+            Some(test.salt)
+        };
+        let (prk2, hkdf) = Hkdf::<H>::extract(salt, test.ikm);
+        let mut okm = &mut buf[..test.okm.len()];
+        assert!(hkdf.expand(&test.info, &mut okm).is_ok());
+
+        assert_eq!(prk2[..], test.prk[..]);
+        assert_eq!(okm, test.okm);
+
+        okm.fill(0);
+        let hkdf = Hkdf::<H>::from_prk(test.prk).unwrap();
+        assert!(hkdf.expand(test.info, okm).is_ok());
+        assert_eq!(okm, test.okm);
+    }
+}
+
+// Test Vectors from https://tools.ietf.org/html/rfc5869.
+#[test]
+fn test_rfc5869_sha256() {
+    rfc_test::<Sha256>(&[
+        // Test Case 1
+        Test {
+            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+            salt: &hex!("000102030405060708090a0b0c"),
+            info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
+            prk: &hex!(
+                "077709362c2e32df0ddc3f0dc47bba63"
+                "90b6c73bb50f9c3122ec844ad7c2b3e5"
+            ),
+            okm: &hex!(
+                "3cb25f25faacd57a90434f64d0362f2a"
+                "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+                "34007208d5b887185865"
+            ),
+        },
+        // Test Case 2
+        Test {
+            ikm: &hex!(
+                "000102030405060708090a0b0c0d0e0f"
+                "101112131415161718191a1b1c1d1e1f"
+                "202122232425262728292a2b2c2d2e2f"
+                "303132333435363738393a3b3c3d3e3f"
+                "404142434445464748494a4b4c4d4e4f"
+            ),
+            salt: &hex!(
+                "606162636465666768696a6b6c6d6e6f"
+                "707172737475767778797a7b7c7d7e7f"
+                "808182838485868788898a8b8c8d8e8f"
+                "909192939495969798999a9b9c9d9e9f"
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+            ),
+            info: &hex!(
+                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+            ),
+            prk: &hex!(
+                "06a6b88c5853361a06104c9ceb35b45c"
+                "ef760014904671014a193f40c15fc244"
+            ),
+            okm: &hex!(
+                "b11e398dc80327a1c8e7f78c596a4934"
+                "4f012eda2d4efad8a050cc4c19afa97c"
+                "59045a99cac7827271cb41c65e590e09"
+                "da3275600c2f09b8367793a9aca3db71"
+                "cc30c58179ec3e87c14c01d5c1f3434f"
+                "1d87"
+            ),
+        },
+        // Test Case 3
+        Test {
+            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+            salt: &hex!(""),
+            info: &hex!(""),
+            prk: &hex!(
+                "19ef24a32c717b167f33a91d6f648bdf"
+                "96596776afdb6377ac434c1c293ccb04"
+            ),
+            okm: &hex!(
+                "8da4e775a563c18f715f802a063c5a31"
+                "b8a11f5c5ee1879ec3454e5f3c738d2d"
+                "9d201395faa4b61a96c8"
+            ),
+        },
+    ]);
+}
+
+#[test]
+fn test_rfc5869_sha1() {
+    rfc_test::<Sha1>(&[
+        // Test Case 4
+        Test {
+            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b"),
+            salt: &hex!("000102030405060708090a0b0c"),
+            info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
+            prk: &hex!("9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243"),
+            okm: &hex!(
+                "085a01ea1b10f36933068b56efa5ad81"
+                "a4f14b822f5b091568a9cdd4f155fda2"
+                "c22e422478d305f3f896"
+            ),
+        },
+        // Test Case 5
+        Test {
+            ikm: &hex!(
+                "000102030405060708090a0b0c0d0e0f"
+                "101112131415161718191a1b1c1d1e1f"
+                "202122232425262728292a2b2c2d2e2f"
+                "303132333435363738393a3b3c3d3e3f"
+                "404142434445464748494a4b4c4d4e4f"
+            ),
+            salt: &hex!(
+                "606162636465666768696a6b6c6d6e6f"
+                "707172737475767778797a7b7c7d7e7f"
+                "808182838485868788898a8b8c8d8e8f"
+                "909192939495969798999a9b9c9d9e9f"
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+            ),
+            info: &hex!(
+                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+            ),
+            prk: &hex!("8adae09a2a307059478d309b26c4115a224cfaf6"),
+            okm: &hex!(
+                "0bd770a74d1160f7c9f12cd5912a06eb"
+                "ff6adcae899d92191fe4305673ba2ffe"
+                "8fa3f1a4e5ad79f3f334b3b202b2173c"
+                "486ea37ce3d397ed034c7f9dfeb15c5e"
+                "927336d0441f4c4300e2cff0d0900b52"
+                "d3b4"
+            ),
+        },
+        // Test Case 6
+        Test {
+            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+            salt: &hex!(""),
+            info: &hex!(""),
+            prk: &hex!("da8c8a73c7fa77288ec6f5e7c297786aa0d32d01"),
+            okm: &hex!(
+                "0ac1af7002b3d761d1e55298da9d0506"
+                "b9ae52057220a306e07b6b87e8df21d0"
+                "ea00033de03984d34918"
+            ),
+        },
+        // Test Case 7
+        Test {
+            ikm: &hex!("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c"),
+            salt: &hex!(""), // "Not Provided"
+            info: &hex!(""),
+            prk: &hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd"),
+            okm: &hex!(
+                "2c91117204d745f3500d636a62f64f0a"
+                "b3bae548aa53d423b0d1f27ebba6f5e5"
+                "673a081d70cce7acfc48"
+            ),
+        },
+    ]);
+}

--- a/hkdf/tests/tests.rs
+++ b/hkdf/tests/tests.rs
@@ -1,7 +1,7 @@
 use core::iter;
 
 use hex_literal::hex;
-use hkdf::{Hkdf, HkdfExtract, SimpleHkdf, SimpleHkdfExtract};
+use hkdf::{Hkdf, HkdfExtract};
 use sha1::Sha1;
 use sha2::{Sha256, Sha384, Sha512};
 
@@ -15,7 +15,6 @@ struct Test<'a> {
 
 // Test Vectors from https://tools.ietf.org/html/rfc5869.
 #[test]
-#[rustfmt::skip]
 fn test_rfc5869_sha256() {
     let tests = [
         Test {
@@ -23,69 +22,76 @@ fn test_rfc5869_sha256() {
             ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
             salt: &hex!("000102030405060708090a0b0c"),
             info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
-            prk: &hex!("
-                077709362c2e32df0ddc3f0dc47bba63
-                90b6c73bb50f9c3122ec844ad7c2b3e5
-            "),
-            okm: &hex!("
-                3cb25f25faacd57a90434f64d0362f2a
-                2d2d0a90cf1a5a4c5db02d56ecc4c5bf
-                34007208d5b887185865
-            "),
+            prk: &hex!(
+                "077709362c2e32df0ddc3f0dc47bba63"
+                "90b6c73bb50f9c3122ec844ad7c2b3e5"
+            ),
+            okm: &hex!(
+                "3cb25f25faacd57a90434f64d0362f2a"
+                "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+                "34007208d5b887185865"
+            ),
         },
         Test {
             // Test Case 2
-            ikm: &hex!("
-                000102030405060708090a0b0c0d0e0f
-                101112131415161718191a1b1c1d1e1f
-                202122232425262728292a2b2c2d2e2f
-                303132333435363738393a3b3c3d3e3f
-                404142434445464748494a4b4c4d4e4f
-            "),
-            salt: &hex!("
-                606162636465666768696a6b6c6d6e6f
-                707172737475767778797a7b7c7d7e7f
-                808182838485868788898a8b8c8d8e8f
-                909192939495969798999a9b9c9d9e9f
-                a0a1a2a3a4a5a6a7a8a9aaabacadaeaf
-            "),
-            info: &hex!("
-                b0b1b2b3b4b5b6b7b8b9babbbcbdbebf
-                c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
-                d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
-                e0e1e2e3e4e5e6e7e8e9eaebecedeeef
-                f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
-            "),
-            prk: &hex!("
-                06a6b88c5853361a06104c9ceb35b45c
-                ef760014904671014a193f40c15fc244
-            "),
-            okm: &hex!("
-                b11e398dc80327a1c8e7f78c596a4934
-                4f012eda2d4efad8a050cc4c19afa97c
-                59045a99cac7827271cb41c65e590e09
-                da3275600c2f09b8367793a9aca3db71
-                cc30c58179ec3e87c14c01d5c1f3434f
-                1d87
-            "),
+            ikm: &hex!(
+                "000102030405060708090a0b0c0d0e0f"
+                "101112131415161718191a1b1c1d1e1f"
+                "202122232425262728292a2b2c2d2e2f"
+                "303132333435363738393a3b3c3d3e3f"
+                "404142434445464748494a4b4c4d4e4f"
+            ),
+            salt: &hex!(
+                "606162636465666768696a6b6c6d6e6f"
+                "707172737475767778797a7b7c7d7e7f"
+                "808182838485868788898a8b8c8d8e8f"
+                "909192939495969798999a9b9c9d9e9f"
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+            ),
+            info: &hex!(
+                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+            ),
+            prk: &hex!(
+                "06a6b88c5853361a06104c9ceb35b45c"
+                "ef760014904671014a193f40c15fc244"
+            ),
+            okm: &hex!(
+                "b11e398dc80327a1c8e7f78c596a4934"
+                "4f012eda2d4efad8a050cc4c19afa97c"
+                "59045a99cac7827271cb41c65e590e09"
+                "da3275600c2f09b8367793a9aca3db71"
+                "cc30c58179ec3e87c14c01d5c1f3434f"
+                "1d87"
+            ),
         },
         Test {
             // Test Case 3
             ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
             salt: &hex!(""),
             info: &hex!(""),
-            prk: &hex!("
-                19ef24a32c717b167f33a91d6f648bdf
-                96596776afdb6377ac434c1c293ccb04
-            "),
-            okm: &hex!("
-                8da4e775a563c18f715f802a063c5a31
-                b8a11f5c5ee1879ec3454e5f3c738d2d
-                9d201395faa4b61a96c8
-            "),
+            prk: &hex!(
+                "19ef24a32c717b167f33a91d6f648bdf"
+                "96596776afdb6377ac434c1c293ccb04"
+            ),
+            okm: &hex!(
+                "8da4e775a563c18f715f802a063c5a31"
+                "b8a11f5c5ee1879ec3454e5f3c738d2d"
+                "9d201395faa4b61a96c8"
+            ),
         },
     ];
-    for Test { ikm, salt, info, prk, okm } in tests.iter() {
+    for Test {
+        ikm,
+        salt,
+        info,
+        prk,
+        okm,
+    } in tests.iter()
+    {
         let salt = if salt.is_empty() {
             None
         } else {
@@ -93,7 +99,7 @@ fn test_rfc5869_sha256() {
         };
         let (prk2, hkdf) = Hkdf::<Sha256>::extract(salt, ikm);
         let mut okm2 = vec![0u8; okm.len()];
-        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
+        assert!(hkdf.expand(&info, &mut okm2).is_ok());
 
         assert_eq!(prk2[..], prk[..]);
         assert_eq!(okm2[..], okm[..]);
@@ -106,7 +112,6 @@ fn test_rfc5869_sha256() {
 }
 
 #[test]
-#[rustfmt::skip]
 fn test_rfc5869_sha1() {
     let tests = [
         Test {
@@ -115,44 +120,44 @@ fn test_rfc5869_sha1() {
             salt: &hex!("000102030405060708090a0b0c"),
             info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
             prk: &hex!("9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243"),
-            okm: &hex!("
-                085a01ea1b10f36933068b56efa5ad81
-                a4f14b822f5b091568a9cdd4f155fda2
-                c22e422478d305f3f896
-            "),
+            okm: &hex!(
+                "085a01ea1b10f36933068b56efa5ad81"
+                "a4f14b822f5b091568a9cdd4f155fda2"
+                "c22e422478d305f3f896"
+            ),
         },
         Test {
             // Test Case 5
-            ikm: &hex!("
-                000102030405060708090a0b0c0d0e0f
-                101112131415161718191a1b1c1d1e1f
-                202122232425262728292a2b2c2d2e2f
-                303132333435363738393a3b3c3d3e3f
-                404142434445464748494a4b4c4d4e4f
-            "),
-            salt: &hex!("
-                606162636465666768696a6b6c6d6e6f
-                707172737475767778797a7b7c7d7e7f
-                808182838485868788898a8b8c8d8e8f
-                909192939495969798999a9b9c9d9e9f
-                a0a1a2a3a4a5a6a7a8a9aaabacadaeaf
-            "),
-            info: &hex!("
-                b0b1b2b3b4b5b6b7b8b9babbbcbdbebf
-                c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
-                d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
-                e0e1e2e3e4e5e6e7e8e9eaebecedeeef
-                f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
-            "),
+            ikm: &hex!(
+                "000102030405060708090a0b0c0d0e0f"
+                "101112131415161718191a1b1c1d1e1f"
+                "202122232425262728292a2b2c2d2e2f"
+                "303132333435363738393a3b3c3d3e3f"
+                "404142434445464748494a4b4c4d4e4f"
+            ),
+            salt: &hex!(
+                "606162636465666768696a6b6c6d6e6f"
+                "707172737475767778797a7b7c7d7e7f"
+                "808182838485868788898a8b8c8d8e8f"
+                "909192939495969798999a9b9c9d9e9f"
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+            ),
+            info: &hex!(
+                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+            ),
             prk: &hex!("8adae09a2a307059478d309b26c4115a224cfaf6"),
-            okm: &hex!("
-                0bd770a74d1160f7c9f12cd5912a06eb
-                ff6adcae899d92191fe4305673ba2ffe
-                8fa3f1a4e5ad79f3f334b3b202b2173c
-                486ea37ce3d397ed034c7f9dfeb15c5e
-                927336d0441f4c4300e2cff0d0900b52
-                d3b4
-            "),
+            okm: &hex!(
+                "0bd770a74d1160f7c9f12cd5912a06eb"
+                "ff6adcae899d92191fe4305673ba2ffe"
+                "8fa3f1a4e5ad79f3f334b3b202b2173c"
+                "486ea37ce3d397ed034c7f9dfeb15c5e"
+                "927336d0441f4c4300e2cff0d0900b52"
+                "d3b4"
+            ),
         },
         Test {
             // Test Case 6
@@ -160,11 +165,11 @@ fn test_rfc5869_sha1() {
             salt: &hex!(""),
             info: &hex!(""),
             prk: &hex!("da8c8a73c7fa77288ec6f5e7c297786aa0d32d01"),
-            okm: &hex!("
-                0ac1af7002b3d761d1e55298da9d0506
-                b9ae52057220a306e07b6b87e8df21d0
-                ea00033de03984d34918
-            "),
+            okm: &hex!(
+                "0ac1af7002b3d761d1e55298da9d0506"
+                "b9ae52057220a306e07b6b87e8df21d0"
+                "ea00033de03984d34918"
+            ),
         },
         Test {
             // Test Case 7
@@ -172,14 +177,21 @@ fn test_rfc5869_sha1() {
             salt: &hex!(""), // "Not Provided"
             info: &hex!(""),
             prk: &hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd"),
-            okm: &hex!("
-                2c91117204d745f3500d636a62f64f0a
-                b3bae548aa53d423b0d1f27ebba6f5e5
-                673a081d70cce7acfc48
-            "),
+            okm: &hex!(
+                "2c91117204d745f3500d636a62f64f0a"
+                "b3bae548aa53d423b0d1f27ebba6f5e5"
+                "673a081d70cce7acfc48"
+            ),
         },
     ];
-    for Test { ikm, salt, info, prk, okm } in tests.iter() {
+    for Test {
+        ikm,
+        salt,
+        info,
+        prk,
+        okm,
+    } in tests.iter()
+    {
         let salt = if salt.is_empty() {
             None
         } else {
@@ -251,7 +263,6 @@ fn test_prk_too_short() {
 }
 
 #[test]
-#[rustfmt::skip]
 fn test_derive_sha1_with_none() {
     let ikm = hex!("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
     let salt = None;
@@ -260,17 +271,40 @@ fn test_derive_sha1_with_none() {
     let mut okm = [0u8; 42];
     assert!(hkdf.expand(&info[..], &mut okm).is_ok());
 
+    assert_eq!(prk.0, hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd"),);
     assert_eq!(
-        prk[..],
-        hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd")[..]
+        okm,
+        hex!(
+            "2c91117204d745f3500d636a62f64f0a"
+            "b3bae548aa53d423b0d1f27ebba6f5e5"
+            "673a081d70cce7acfc48"
+        ),
+    );
+}
+
+#[test]
+fn test_derive_blake2s_with_none() {
+    let ikm = hex!("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
+    let salt = None;
+    let info = hex!("");
+    let (prk, hkdf) = Hkdf::<blake2::Blake2s256>::extract(salt, &ikm[..]);
+    let mut okm = [0u8; 42];
+    assert!(hkdf.expand(&info[..], &mut okm).is_ok());
+
+    assert_eq!(
+        prk.0,
+        hex!(
+            "168101a1dfa3abe6fb9e16edad615622"
+            "c579a6e46979ae7de1a45fc6b08718f1"
+        ),
     );
     assert_eq!(
-        okm[..],
-        hex!("
-            2c91117204d745f3500d636a62f64f0a
-            b3bae548aa53d423b0d1f27ebba6f5e5
-            673a081d70cce7acfc48
-        ")[..],
+        okm,
+        hex!(
+            "19e0c918842fbc18ebd79cbcdb233ded"
+            "1fee810d854fe099b670674b25d82858"
+            "852ebcf9bf8cc9ebebff"
+        ),
     );
 }
 
@@ -364,7 +398,7 @@ fn test_extract_streaming() {
 
         // Make a new extraction context and build the new input to be the IKM head followed by the
         // remaining components
-        let mut extract_ctx = SimpleHkdfExtract::<Sha256>::new(Some(&salt[..]));
+        let mut extract_ctx = HkdfExtract::<Sha256>::new(Some(&salt[..]));
         let input = iter::once(ikm_head.as_slice())
             .chain(ikm_components.iter().cloned().skip(num_concatted + 1));
 
@@ -426,25 +460,21 @@ new_test!(wycheproof_sha256, "wycheproof-sha256", Hkdf::<Sha256>);
 new_test!(wycheproof_sha384, "wycheproof-sha384", Hkdf::<Sha384>);
 new_test!(wycheproof_sha512, "wycheproof-sha512", Hkdf::<Sha512>);
 
-new_test!(
-    wycheproof_sha1_simple,
-    "wycheproof-sha1",
-    SimpleHkdf::<Sha1>
-);
+new_test!(wycheproof_sha1_simple, "wycheproof-sha1", Hkdf::<Sha1>);
 new_test!(
     wycheproof_sha256_simple,
     "wycheproof-sha256",
-    SimpleHkdf::<Sha256>
+    Hkdf::<Sha256>
 );
 new_test!(
     wycheproof_sha384_simple,
     "wycheproof-sha384",
-    SimpleHkdf::<Sha384>
+    Hkdf::<Sha384>
 );
 new_test!(
     wycheproof_sha512_simple,
     "wycheproof-sha512",
-    SimpleHkdf::<Sha512>
+    Hkdf::<Sha512>
 );
 
 #[test]

--- a/hkdf/tests/tests.rs
+++ b/hkdf/tests/tests.rs
@@ -3,215 +3,16 @@ use core::iter;
 use hex_literal::hex;
 use hkdf::{Hkdf, HkdfExtract};
 use sha1::Sha1;
-use sha2::{Sha256, Sha384, Sha512};
-
-struct Test<'a> {
-    ikm: &'a [u8],
-    salt: &'a [u8],
-    info: &'a [u8],
-    prk: &'a [u8],
-    okm: &'a [u8],
-}
-
-// Test Vectors from https://tools.ietf.org/html/rfc5869.
-#[test]
-fn test_rfc5869_sha256() {
-    let tests = [
-        Test {
-            // Test Case 1
-            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
-            salt: &hex!("000102030405060708090a0b0c"),
-            info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
-            prk: &hex!(
-                "077709362c2e32df0ddc3f0dc47bba63"
-                "90b6c73bb50f9c3122ec844ad7c2b3e5"
-            ),
-            okm: &hex!(
-                "3cb25f25faacd57a90434f64d0362f2a"
-                "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
-                "34007208d5b887185865"
-            ),
-        },
-        Test {
-            // Test Case 2
-            ikm: &hex!(
-                "000102030405060708090a0b0c0d0e0f"
-                "101112131415161718191a1b1c1d1e1f"
-                "202122232425262728292a2b2c2d2e2f"
-                "303132333435363738393a3b3c3d3e3f"
-                "404142434445464748494a4b4c4d4e4f"
-            ),
-            salt: &hex!(
-                "606162636465666768696a6b6c6d6e6f"
-                "707172737475767778797a7b7c7d7e7f"
-                "808182838485868788898a8b8c8d8e8f"
-                "909192939495969798999a9b9c9d9e9f"
-                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
-            ),
-            info: &hex!(
-                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
-                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
-                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
-                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
-            ),
-            prk: &hex!(
-                "06a6b88c5853361a06104c9ceb35b45c"
-                "ef760014904671014a193f40c15fc244"
-            ),
-            okm: &hex!(
-                "b11e398dc80327a1c8e7f78c596a4934"
-                "4f012eda2d4efad8a050cc4c19afa97c"
-                "59045a99cac7827271cb41c65e590e09"
-                "da3275600c2f09b8367793a9aca3db71"
-                "cc30c58179ec3e87c14c01d5c1f3434f"
-                "1d87"
-            ),
-        },
-        Test {
-            // Test Case 3
-            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
-            salt: &hex!(""),
-            info: &hex!(""),
-            prk: &hex!(
-                "19ef24a32c717b167f33a91d6f648bdf"
-                "96596776afdb6377ac434c1c293ccb04"
-            ),
-            okm: &hex!(
-                "8da4e775a563c18f715f802a063c5a31"
-                "b8a11f5c5ee1879ec3454e5f3c738d2d"
-                "9d201395faa4b61a96c8"
-            ),
-        },
-    ];
-    for Test {
-        ikm,
-        salt,
-        info,
-        prk,
-        okm,
-    } in tests.iter()
-    {
-        let salt = if salt.is_empty() {
-            None
-        } else {
-            Some(&salt[..])
-        };
-        let (prk2, hkdf) = Hkdf::<Sha256>::extract(salt, ikm);
-        let mut okm2 = vec![0u8; okm.len()];
-        assert!(hkdf.expand(&info, &mut okm2).is_ok());
-
-        assert_eq!(prk2[..], prk[..]);
-        assert_eq!(okm2[..], okm[..]);
-
-        okm2.iter_mut().for_each(|b| *b = 0);
-        let hkdf = Hkdf::<Sha256>::from_prk(prk).unwrap();
-        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
-        assert_eq!(okm2[..], okm[..]);
-    }
-}
-
-#[test]
-fn test_rfc5869_sha1() {
-    let tests = [
-        Test {
-            // Test Case 4
-            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b"),
-            salt: &hex!("000102030405060708090a0b0c"),
-            info: &hex!("f0f1f2f3f4f5f6f7f8f9"),
-            prk: &hex!("9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243"),
-            okm: &hex!(
-                "085a01ea1b10f36933068b56efa5ad81"
-                "a4f14b822f5b091568a9cdd4f155fda2"
-                "c22e422478d305f3f896"
-            ),
-        },
-        Test {
-            // Test Case 5
-            ikm: &hex!(
-                "000102030405060708090a0b0c0d0e0f"
-                "101112131415161718191a1b1c1d1e1f"
-                "202122232425262728292a2b2c2d2e2f"
-                "303132333435363738393a3b3c3d3e3f"
-                "404142434445464748494a4b4c4d4e4f"
-            ),
-            salt: &hex!(
-                "606162636465666768696a6b6c6d6e6f"
-                "707172737475767778797a7b7c7d7e7f"
-                "808182838485868788898a8b8c8d8e8f"
-                "909192939495969798999a9b9c9d9e9f"
-                "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
-            ),
-            info: &hex!(
-                "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
-                "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
-                "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-                "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
-                "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
-            ),
-            prk: &hex!("8adae09a2a307059478d309b26c4115a224cfaf6"),
-            okm: &hex!(
-                "0bd770a74d1160f7c9f12cd5912a06eb"
-                "ff6adcae899d92191fe4305673ba2ffe"
-                "8fa3f1a4e5ad79f3f334b3b202b2173c"
-                "486ea37ce3d397ed034c7f9dfeb15c5e"
-                "927336d0441f4c4300e2cff0d0900b52"
-                "d3b4"
-            ),
-        },
-        Test {
-            // Test Case 6
-            ikm: &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
-            salt: &hex!(""),
-            info: &hex!(""),
-            prk: &hex!("da8c8a73c7fa77288ec6f5e7c297786aa0d32d01"),
-            okm: &hex!(
-                "0ac1af7002b3d761d1e55298da9d0506"
-                "b9ae52057220a306e07b6b87e8df21d0"
-                "ea00033de03984d34918"
-            ),
-        },
-        Test {
-            // Test Case 7
-            ikm: &hex!("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c"),
-            salt: &hex!(""), // "Not Provided"
-            info: &hex!(""),
-            prk: &hex!("2adccada18779e7c2077ad2eb19d3f3e731385dd"),
-            okm: &hex!(
-                "2c91117204d745f3500d636a62f64f0a"
-                "b3bae548aa53d423b0d1f27ebba6f5e5"
-                "673a081d70cce7acfc48"
-            ),
-        },
-    ];
-    for Test {
-        ikm,
-        salt,
-        info,
-        prk,
-        okm,
-    } in tests.iter()
-    {
-        let salt = if salt.is_empty() {
-            None
-        } else {
-            Some(&salt[..])
-        };
-        let (prk2, hkdf) = Hkdf::<Sha1>::extract(salt, ikm);
-        let mut okm2 = vec![0u8; okm.len()];
-        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
-
-        assert_eq!(prk2[..], prk[..]);
-        assert_eq!(okm2[..], okm[..]);
-
-        okm2.iter_mut().for_each(|b| *b = 0);
-        let hkdf = Hkdf::<Sha1>::from_prk(prk).unwrap();
-        assert!(hkdf.expand(&info[..], &mut okm2).is_ok());
-        assert_eq!(okm2[..], okm[..]);
-    }
-}
+use sha2::Sha256;
 
 const MAX_SHA256_LENGTH: usize = 255 * (256 / 8); // =8160
+static COMPONENTS: &[&[u8]] = &[
+    b"09090909090909090909090909090909090909090909",
+    b"8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a",
+    b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0",
+    b"4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4",
+    b"1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d",
+];
 
 #[test]
 fn test_lengths() {
@@ -310,13 +111,7 @@ fn test_derive_blake2s_with_none() {
 
 #[test]
 fn test_expand_multi_info() {
-    let info_components = &[
-        &b"09090909090909090909090909090909090909090909"[..],
-        &b"8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a"[..],
-        &b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"[..],
-        &b"4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4"[..],
-        &b"1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"[..],
-    ];
+    let info_components = COMPONENTS;
 
     let (_, hkdf_ctx) = Hkdf::<Sha256>::extract(None, b"some ikm here");
 
@@ -352,13 +147,7 @@ fn test_expand_multi_info() {
 
 #[test]
 fn test_extract_streaming() {
-    let ikm_components = &[
-        &b"09090909090909090909090909090909090909090909"[..],
-        &b"8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a"[..],
-        &b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"[..],
-        &b"4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4c4"[..],
-        &b"1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"[..],
-    ];
+    let ikm_components = COMPONENTS;
     let salt = b"mysalt";
 
     // Compute HKDF-Extract on the concatenation of all the IKM components
@@ -414,68 +203,6 @@ fn test_extract_streaming() {
         num_concatted += 1;
     }
 }
-
-/// Define test
-macro_rules! new_test {
-    ($name:ident, $test_name:expr, $hkdf:ty) => {
-        #[test]
-        fn $name() {
-            use blobby::Blob4Iterator;
-
-            fn run_test(ikm: &[u8], salt: &[u8], info: &[u8], okm: &[u8]) -> Option<&'static str> {
-                let prk = <$hkdf>::new(Some(salt), ikm);
-                let mut got_okm = vec![0; okm.len()];
-
-                if prk.expand(info, &mut got_okm).is_err() {
-                    return Some("prk expand");
-                }
-                if got_okm != okm {
-                    return Some("mismatch in okm");
-                }
-                None
-            }
-
-            let data = include_bytes!(concat!("data/", $test_name, ".blb"));
-
-            for (i, row) in Blob4Iterator::new(data).unwrap().enumerate() {
-                let [ikm, salt, info, okm] = row.unwrap();
-                if let Some(desc) = run_test(ikm, salt, info, okm) {
-                    panic!(
-                        "\n\
-                         Failed test №{}: {}\n\
-                         ikm:\t{:?}\n\
-                         salt:\t{:?}\n\
-                         info:\t{:?}\n\
-                         okm:\t{:?}\n",
-                        i, desc, ikm, salt, info, okm
-                    );
-                }
-            }
-        }
-    };
-}
-
-new_test!(wycheproof_sha1, "wycheproof-sha1", Hkdf::<Sha1>);
-new_test!(wycheproof_sha256, "wycheproof-sha256", Hkdf::<Sha256>);
-new_test!(wycheproof_sha384, "wycheproof-sha384", Hkdf::<Sha384>);
-new_test!(wycheproof_sha512, "wycheproof-sha512", Hkdf::<Sha512>);
-
-new_test!(wycheproof_sha1_simple, "wycheproof-sha1", Hkdf::<Sha1>);
-new_test!(
-    wycheproof_sha256_simple,
-    "wycheproof-sha256",
-    Hkdf::<Sha256>
-);
-new_test!(
-    wycheproof_sha384_simple,
-    "wycheproof-sha384",
-    Hkdf::<Sha384>
-);
-new_test!(
-    wycheproof_sha512_simple,
-    "wycheproof-sha512",
-    Hkdf::<Sha512>
-);
 
 #[test]
 fn test_debug_impls() {

--- a/hkdf/tests/wycheproof.rs
+++ b/hkdf/tests/wycheproof.rs
@@ -1,0 +1,48 @@
+use hkdf::Hkdf;
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
+
+/// Define test
+macro_rules! new_test {
+    ($name:ident, $test_name:expr, $hash:ty) => {
+        #[test]
+        fn $name() {
+            use blobby::Blob4Iterator;
+
+            fn run_test(ikm: &[u8], salt: &[u8], info: &[u8], okm: &[u8]) -> Option<&'static str> {
+                let prk = Hkdf::<$hash>::new(Some(salt), ikm);
+                let mut got_okm = vec![0; okm.len()];
+
+                if prk.expand(info, &mut got_okm).is_err() {
+                    return Some("prk expand");
+                }
+                if got_okm != okm {
+                    return Some("mismatch in okm");
+                }
+                None
+            }
+
+            let data = include_bytes!(concat!("data/", $test_name, ".blb"));
+
+            for (i, row) in Blob4Iterator::new(data).unwrap().enumerate() {
+                let [ikm, salt, info, okm] = row.unwrap();
+                if let Some(desc) = run_test(ikm, salt, info, okm) {
+                    panic!(
+                        "\n\
+                         Failed test №{}: {}\n\
+                         ikm:\t{:?}\n\
+                         salt:\t{:?}\n\
+                         info:\t{:?}\n\
+                         okm:\t{:?}\n",
+                        i, desc, ikm, salt, info, okm
+                    );
+                }
+            }
+        }
+    };
+}
+
+new_test!(wycheproof_sha1, "wycheproof-sha1", Sha1);
+new_test!(wycheproof_sha256, "wycheproof-sha256", Sha256);
+new_test!(wycheproof_sha384, "wycheproof-sha384", Sha384);
+new_test!(wycheproof_sha512, "wycheproof-sha512", Sha512);


### PR DESCRIPTION
With this change the implementation automatically selects `Hmac` for "eager" hashes and `SimpleHmac` for "lazy" ones.

The main disadvantage of this approach is that new `Hkdf` will work only for hash functions defined using `CoreWrapper`. Ideally, we would use specialization here, but we probably can work around this by tweaking `digest` and `hmac`. We need to distinguish between eager hashes which can return hash "core" and other hashes. Plus, it should be done in a way which allows compiler to see that implementations in this crate do not overlap.