### PR TITLE
ansi-x963-kdf: minor tweaks

### DIFF
--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ansi-x963-kdf"
 version = "0.1.0"
-description = "ANSI X9.63 Key Derivation Function (ANSI-X9.63-KDF)"
+description = "ANSI X9.63 Key Derivation Function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
 [features]
-std = []
+alloc = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ansi-x963-kdf/LICENSE-APACHE
+++ b/ansi-x963-kdf/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ansi-x963-kdf/LICENSE-MIT
+++ b/ansi-x963-kdf/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2024 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ansi-x963-kdf/README.md
+++ b/ansi-x963-kdf/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: ANSI X9.63 Key Derivation Function (ANSI-X9.63-KDF)
+# RustCrypto: ANSI X9.63 Key Derivation Function
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -12,17 +12,21 @@ This function is described in the section 3.6.1 of [SEC 1: Elliptic Curve Crypto
 
 # Usage
 
-The most common way to use ANSI-X9.63-KDF is as follows: you generate a shared secret with other party (e.g. via Diffie-Hellman algorithm) 
-and use key derivation function to derive a shared key.
+The most common way to use ANSI-X9.63-KDF is as follows: you generate a shared secret with other
+party (e.g. via Diffie-Hellman algorithm)  and use key derivation function to derive a shared key.
 
 ```rust
-let mut key = [0u8; 32];
-ansi_x963_kdf::derive_key_into::<sha2::Sha256>(b"shared-secret", b"other-info", &mut key).unwrap();
+use hex_literal::hex;
+use sha2::Sha256;
+
+let mut key = [0u8; 16];
+ansi_x963_kdf::derive_key_into::<Sha256>(b"secret", b"shared-info", &mut key).unwrap();
+assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
 ```
 
 ## Minimum Supported Rust Version
 
-Rust **1.72** or higher.
+Rust **1.81** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -52,7 +56,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ansi-x963-kdf/badge.svg
 [docs-link]: https://docs.rs/ansi-x963-kdf/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260043-KDFs
 [build-image]: https://github.com/RustCrypto/KDFs/workflows/ansi-x963-kdf/badge.svg?branch=master&event=push

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -45,6 +45,7 @@ impl ::core::error::Error for Error {}
 /// ansi_x963_kdf::derive_key_into::<Sha256>(b"secret", b"shared-info", &mut key).unwrap();
 /// assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
 /// ```
+#[inline]
 pub fn derive_key_into<D>(secret: &[u8], shared_info: &[u8], key: &mut [u8]) -> Result<(), Error>
 where
     D: Digest + FixedOutputReset,
@@ -100,6 +101,7 @@ where
 /// assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
 /// ```
 #[cfg(feature = "alloc")]
+#[inline]
 pub fn derive_key<D>(
     secret: &[u8],
     shared_info: &[u8],

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -97,7 +97,7 @@ where
 /// use hex_literal::hex;
 /// use sha2::Sha256;
 ///
-/// let key = ansi_x963_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 42).unwrap();
+/// let key = ansi_x963_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 16).unwrap();
 /// assert_eq!(key[..], hex!("8dbb1d50bcc7fc782abc9db5c64a2826")[..]);
 /// ```
 #[cfg(feature = "alloc")]

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -98,7 +98,7 @@ where
 /// use sha2::Sha256;
 ///
 /// let key = ansi_x963_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 42).unwrap();
-/// assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
+/// assert_eq!(key[..], hex!("8dbb1d50bcc7fc782abc9db5c64a2826")[..]);
 /// ```
 #[cfg(feature = "alloc")]
 #[inline]

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -1,28 +1,12 @@
-//! An implementation of ANSI-X9.63 KDF Key Derivation Function.
-//!
-//! This function is described in the section 3.6.1 of [SEC 1: Elliptic Curve Cryptography][1].
-//!
-//! # Usage
-//!
-//! The most common way to use ANSI-X9.63 KDF is as follows: you generate a shared secret
-//! with other party (e.g. via Diffie-Hellman algorithm) and use key derivation function
-//! to derive a shared key.
-//!
-//! ```rust
-//! let mut key = [0u8; 32];
-//! ansi_x963_kdf::derive_key_into::<sha2::Sha256>(b"shared-secret", b"other-info", &mut key).unwrap();
-//! ```
-//!
-//! [1]: https://www.secg.org/sec1-v2.pdf
-
 #![no_std]
+#![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt;
 use digest::{array::typenum::Unsigned, Digest, FixedOutputReset};
 
-#[cfg(feature = "std")]
-extern crate std;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 /// ANSI-X9.63 KDF errors.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -51,11 +35,15 @@ impl fmt::Display for Error {
 impl ::core::error::Error for Error {}
 
 /// Derives `key` in-place from `secret` and `shared_info`.
-/// ```rust
+///
+/// # Example
+/// ```
 /// use hex_literal::hex;
-/// let mut key = [0u8; 42];
-/// ansi_x963_kdf::derive_key_into::<sha2::Sha256>(b"top-secret", b"info", &mut key).unwrap();
-/// assert_eq!(key, hex!("85397c03b3894cdc12e7e042698d040f449dbff97a86d0a4dd2d0a4409b8d969e01e57091cf170dfd977"));
+/// use sha2::Sha256;
+///
+/// let mut key = [0u8; 16];
+/// ansi_x963_kdf::derive_key_into::<Sha256>(b"secret", b"shared-info", &mut key).unwrap();
+/// assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
 /// ```
 pub fn derive_key_into<D>(secret: &[u8], shared_info: &[u8], key: &mut [u8]) -> Result<(), Error>
 where
@@ -102,22 +90,25 @@ where
 }
 
 /// Derives and returns `length` bytes key from `secret` and `shared_info`.
-/// ```rust
-/// use hex_literal::hex;
-/// let key = ansi_x963_kdf::derive_key::<sha2::Sha256>(b"top-secret", b"info", 42).unwrap();
-/// assert_eq!(key, hex!("85397c03b3894cdc12e7e042698d040f449dbff97a86d0a4dd2d0a4409b8d969e01e57091cf170dfd977"));
+///
+/// # Example
 /// ```
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+/// use hex_literal::hex;
+/// use sha2::Sha256;
+///
+/// let key = ansi_x963_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 42).unwrap();
+/// assert_eq!(key, hex!("8dbb1d50bcc7fc782abc9db5c64a2826"));
+/// ```
+#[cfg(feature = "alloc")]
 pub fn derive_key<D>(
     secret: &[u8],
     shared_info: &[u8],
     length: usize,
-) -> Result<std::vec::Vec<u8>, Error>
+) -> Result<alloc::boxed::Box<[u8]>, Error>
 where
     D: Digest + FixedOutputReset,
 {
-    let mut key = std::vec![0u8; length];
+    let mut key = alloc::vec![0u8; length].into_boxed_slice();
     derive_key_into::<D>(secret, shared_info, &mut key)?;
     Ok(key)
 }

--- a/ansi-x963-kdf/tests/tests.rs
+++ b/ansi-x963-kdf/tests/tests.rs
@@ -18,16 +18,12 @@ fn test_key_derivation<D>(fixtures: &[Fixture])
 where
     D: Digest + FixedOutputReset,
 {
-    for Fixture {
-        secret,
-        shared_info,
-        expected_key,
-    } in fixtures.iter()
-    {
-        for key_length in 1..expected_key.len() {
-            let mut key = vec![0u8; key_length];
-            assert!(ansi_x963_kdf::derive_key_into::<D>(secret, shared_info, &mut key).is_ok());
-            assert_eq!(&expected_key[..key_length], &key);
+    for f in fixtures.iter() {
+        let mut buf = [0; 256];
+        for key_length in 1..f.expected_key.len() {
+            let key = &mut buf[..key_length];
+            ansi_x963_kdf::derive_key_into::<D>(f.secret, f.shared_info, key).unwrap();
+            assert_eq!(&f.expected_key[..key_length], key);
         }
     }
 }
@@ -39,38 +35,38 @@ fn test_input_output_sha224() {
             secret: &hex!("00"),
             shared_info: &[],
             expected_key: &hex!(
-                "4a6ebc83b8e2b19eea640500be6bcffdddaa07b8b2f81f2c533940e4e6ad6cfd
-                 e680e5ba8eb25351402f0e75a6246cf006f6dd2187185af41d04abb648124e27
-                 827cf4f2b871f9bc3fb2313c4f146b44faf3be170f2d87296c9b533c516b9a48
-                 dc73f73bafcc610bce18965566e3d0ca0f083c8a6a20b3b84457486e204a1014"
+                "4a6ebc83b8e2b19eea640500be6bcffdddaa07b8b2f81f2c533940e4e6ad6cfd"
+                "e680e5ba8eb25351402f0e75a6246cf006f6dd2187185af41d04abb648124e27"
+                "827cf4f2b871f9bc3fb2313c4f146b44faf3be170f2d87296c9b533c516b9a48"
+                "dc73f73bafcc610bce18965566e3d0ca0f083c8a6a20b3b84457486e204a1014"
             ),
         },
         Fixture {
             secret: &hex!("00"),
             shared_info: &hex!("00"),
             expected_key: &hex!(
-                "4bfb11552c4bf91bce4833aa06f854ceb8a3f7e435f42907e6d86e7597b20789
-                 aba17dccaf09d3e26bc3dd0ad6051f0e46b830cc57091bd0ba1da24a4ab96492
-                 3b47b4b73ccb6cec6aa1e6339f4fa93995baef4a3ace3cadcf1ee63eaecb868f
-                 2f8ca06def29797d33673803a185574dec0c4bc0a5d0d0ffb4c527eb738d5bd2
-                 4fcc424f46785f693f60ea2f00d3ff38f9f1e73847a50bf6ece7bda4abe3767f
-                 19f0a767f2ea69ed84f4f5837084edd2945c39d4b459b38fc2e83264ba47896a
-                 a3e106058f1d13f2b1422c7ff33c279dfc7a42cc4f775babcae8122a4dbdf427
-                 a8634e9464607fe4a6f91fc59f07ab42f18dac313384b50d572cdff0b406cff2"
+                "4bfb11552c4bf91bce4833aa06f854ceb8a3f7e435f42907e6d86e7597b20789"
+                "aba17dccaf09d3e26bc3dd0ad6051f0e46b830cc57091bd0ba1da24a4ab96492"
+                "3b47b4b73ccb6cec6aa1e6339f4fa93995baef4a3ace3cadcf1ee63eaecb868f"
+                "2f8ca06def29797d33673803a185574dec0c4bc0a5d0d0ffb4c527eb738d5bd2"
+                "4fcc424f46785f693f60ea2f00d3ff38f9f1e73847a50bf6ece7bda4abe3767f"
+                "19f0a767f2ea69ed84f4f5837084edd2945c39d4b459b38fc2e83264ba47896a"
+                "a3e106058f1d13f2b1422c7ff33c279dfc7a42cc4f775babcae8122a4dbdf427"
+                "a8634e9464607fe4a6f91fc59f07ab42f18dac313384b50d572cdff0b406cff2"
             ),
         },
         Fixture {
             secret: &hex!("ba5eba11bedabb1ebe5077edb0a710adb01dfacecab005eca11ab1eca55e77e011"),
             shared_info: &hex!("f005ba1100ddba11"),
             expected_key: &hex!(
-                "20328557e258ecbe845fcde1002aa36dba5e29383d1b9813c2410819c09bd7d7
-                 5b75f4d2ca71354080b64b3e8e3ef457f22517b074cbbbbf11d660b7b4706de1
-                 5678893c6712e104b34fb776a90341c905a028bf1892aa4487899ef4436f4ac6
-                 d436db25763c7fa7d43fbedac386aa69f5b156d4a84ede0b4371d34eb083fce1
-                 6cb6e051e846a923a82707925838371797b09fc94134d33b48e0ab9175fdbd90
-                 cd57b1570d55f5d4a391f5c15660757c447e0480bd6b6f0ca80a4e3ab5c40220
-                 7d1edcc2210eb77aff4eda6e35afce2815d82ab242574b7b9d0e72d8daa1c853
-                 e0b3dad4cb384ce70c5a23afd4f1e35a01fdd14f78812a5a99a93f4d57877901"
+                "20328557e258ecbe845fcde1002aa36dba5e29383d1b9813c2410819c09bd7d7"
+                "5b75f4d2ca71354080b64b3e8e3ef457f22517b074cbbbbf11d660b7b4706de1"
+                "5678893c6712e104b34fb776a90341c905a028bf1892aa4487899ef4436f4ac6"
+                "d436db25763c7fa7d43fbedac386aa69f5b156d4a84ede0b4371d34eb083fce1"
+                "6cb6e051e846a923a82707925838371797b09fc94134d33b48e0ab9175fdbd90"
+                "cd57b1570d55f5d4a391f5c15660757c447e0480bd6b6f0ca80a4e3ab5c40220"
+                "7d1edcc2210eb77aff4eda6e35afce2815d82ab242574b7b9d0e72d8daa1c853"
+                "e0b3dad4cb384ce70c5a23afd4f1e35a01fdd14f78812a5a99a93f4d57877901"
             ),
         },
     ];
@@ -85,42 +81,42 @@ fn test_input_output_sha256() {
             secret: &hex!("00"),
             shared_info: &[],
             expected_key: &hex!(
-                "15f2f1a4339f5f2a313b95015cad8124d054a171ac2f31cf529dda7cfb6a38b4
-                 89eefc18fa4b815bd1aded2f24eb28885993aa00b6d0171bf5005f9d39aaea10
-                 016a682d1df4f869b32c48b0a9b442a1493949fb85d951d121c1143bd3d5c1af
-                 b59024333110b3108625f25447665c1ebf10c6a6bbe9f018c421f4b0dcb5a993
-                 42a5578600f1b0902c599a39268c12bdb1e820fd9a82212db588a71ae74cb6e4
-                 1f8a792ae7c5800a0b0e3aea6ed808bedca2b0a3cc8f7b22c5effbd545f632c2
-                 043a0631871a3f67ac03c5f8406b69a0dc14bd5b23e55f27a5d4462b0f0a2d23
-                 18519afd330d3447bb196dd75ea7a7998db6f2fcb2a5dc134f35690a2dbcc072"
+                "15f2f1a4339f5f2a313b95015cad8124d054a171ac2f31cf529dda7cfb6a38b4"
+                "89eefc18fa4b815bd1aded2f24eb28885993aa00b6d0171bf5005f9d39aaea10"
+                "016a682d1df4f869b32c48b0a9b442a1493949fb85d951d121c1143bd3d5c1af"
+                "b59024333110b3108625f25447665c1ebf10c6a6bbe9f018c421f4b0dcb5a993"
+                "42a5578600f1b0902c599a39268c12bdb1e820fd9a82212db588a71ae74cb6e4"
+                "1f8a792ae7c5800a0b0e3aea6ed808bedca2b0a3cc8f7b22c5effbd545f632c2"
+                "043a0631871a3f67ac03c5f8406b69a0dc14bd5b23e55f27a5d4462b0f0a2d23"
+                "18519afd330d3447bb196dd75ea7a7998db6f2fcb2a5dc134f35690a2dbcc072"
             ),
         },
         Fixture {
             secret: &hex!("00"),
             shared_info: &hex!("00"),
             expected_key: &hex!(
-                "588611f65741c171a3d92c1d5343f5dd67f4fc472fc56f01c9bc568f5ac2a623
-                 55af2e3db27cf364b9465ea89a489710da6c78ecc59ddf3ac6203261a6649d9e
-                 45673cfcd9849e761a24b07d99f5c35167c343244c160b973b55a29408d9d988
-                 654670625fbd22634494df9f4f9a5328352eb92b4104612eef6dff382c119064
-                 785b35d50e5df9eee4bb06e5b102b1088d149500e934c04eac6936a09e4b36d1
-                 1e4f69ae41148ec0d7b5cca9bde9db8b850660e759c75f32154bb60357145ed3
-                 c0112a61a92f4eacd699c70a603df40f38babf6420587478c05ec70670e7221e
-                 ce2081d38382369c0d2ec51f89db2e29146d555c7c2aa62518962824682553a7"
+                "588611f65741c171a3d92c1d5343f5dd67f4fc472fc56f01c9bc568f5ac2a623"
+                "55af2e3db27cf364b9465ea89a489710da6c78ecc59ddf3ac6203261a6649d9e"
+                "45673cfcd9849e761a24b07d99f5c35167c343244c160b973b55a29408d9d988"
+                "654670625fbd22634494df9f4f9a5328352eb92b4104612eef6dff382c119064"
+                "785b35d50e5df9eee4bb06e5b102b1088d149500e934c04eac6936a09e4b36d1"
+                "1e4f69ae41148ec0d7b5cca9bde9db8b850660e759c75f32154bb60357145ed3"
+                "c0112a61a92f4eacd699c70a603df40f38babf6420587478c05ec70670e7221e"
+                "ce2081d38382369c0d2ec51f89db2e29146d555c7c2aa62518962824682553a7"
             ),
         },
         Fixture {
             secret: &hex!("ba5eba11bedabb1ebe5077edb0a710adb01dfacecab005eca11ab1eca55e77e011"),
             shared_info: &hex!("f005ba1100ddba11"),
             expected_key: &hex!(
-                "41bf219e0dedf77305f1f79739fd917b3311e61dd504150d6f3c40195837c75a
-                 441fd05332d739a43fd70e11e4be66683eb05586c6c03bbf6d8030990e724a38
-                 c2ab1f5c22b0f47a84a2699d11701c6bfb3337e606130522f4f7a26df3b1cb95
-                 28ca56781af9af361e7c2ac64d50f73d275d5a6c83fc67b2e05f20ab9b595cce
-                 b8f205c57993647bf64c6f4ad8899eb5d0111efed1859006ec256b2e8cbb058b
-                 b83a8d40fa7f435037acd155b27a87716fdd7619b900f051a2437539f830789b
-                 f71080ff642285a01ff2db3e11ca5377c389be3f3851611cc8189728496fddca
-                 cac6b89565fd78a1b8d4c8d407ff45e39610526668abacabede347d5c1e9fb69"
+                "41bf219e0dedf77305f1f79739fd917b3311e61dd504150d6f3c40195837c75a"
+                "441fd05332d739a43fd70e11e4be66683eb05586c6c03bbf6d8030990e724a38"
+                "c2ab1f5c22b0f47a84a2699d11701c6bfb3337e606130522f4f7a26df3b1cb95"
+                "28ca56781af9af361e7c2ac64d50f73d275d5a6c83fc67b2e05f20ab9b595cce"
+                "b8f205c57993647bf64c6f4ad8899eb5d0111efed1859006ec256b2e8cbb058b"
+                "b83a8d40fa7f435037acd155b27a87716fdd7619b900f051a2437539f830789b"
+                "f71080ff642285a01ff2db3e11ca5377c389be3f3851611cc8189728496fddca"
+                "cac6b89565fd78a1b8d4c8d407ff45e39610526668abacabede347d5c1e9fb69"
             ),
         },
     ];
@@ -135,42 +131,42 @@ fn test_input_output_sha512() {
             secret: &hex!("00"),
             shared_info: &[],
             expected_key: &hex!(
-                "b8eef223e484fe7a872e4db84711a01db365b205e477c3e3170f26623e2fa230
-                 4d93f6c04337d0ea7454d1f2073f8eb8ee58b361438b61f363eb1037a77f716c
-                 e89b92de1146cf3831eff44361d872f61dea1f05b3e08a9330c302949f6c93bd
-                 3e908f5ce5444e45a47bc0625600fff575472f04bcecc393387c244a93fbd4f4
-                 26b22edbdaa5eef8565feb1d6a3c46dedb89c00efcaf3f5d95d53f936b570efb
-                 18db044083a075f3d1322378a07f00694e4e21a535d91e893cacac87d877b2ab
-                 da0cff964fd1c291b759c38657bc7904be9f98cc8794099a6351b68f382e2df8
-                 79cab5d5a1d7f5e9d6461f015b11c47fb14cf99e496905fa95e8d7d5ec59a493"
+                "b8eef223e484fe7a872e4db84711a01db365b205e477c3e3170f26623e2fa230"
+                "4d93f6c04337d0ea7454d1f2073f8eb8ee58b361438b61f363eb1037a77f716c"
+                "e89b92de1146cf3831eff44361d872f61dea1f05b3e08a9330c302949f6c93bd"
+                "3e908f5ce5444e45a47bc0625600fff575472f04bcecc393387c244a93fbd4f4"
+                "26b22edbdaa5eef8565feb1d6a3c46dedb89c00efcaf3f5d95d53f936b570efb"
+                "18db044083a075f3d1322378a07f00694e4e21a535d91e893cacac87d877b2ab"
+                "da0cff964fd1c291b759c38657bc7904be9f98cc8794099a6351b68f382e2df8"
+                "79cab5d5a1d7f5e9d6461f015b11c47fb14cf99e496905fa95e8d7d5ec59a493"
             ),
         },
         Fixture {
             secret: &hex!("00"),
             shared_info: &hex!("00"),
             expected_key: &hex!(
-                "74cc6e00677ea1683c3c3fbc6337101db4e2ffdd0053a8783fd4c9f5b53117db
-                 9089ce3beef287cbe273a7c47ad1e88509842f9a70ff354280dc7a8e1c61214a
-                 e698b4186af5628a28dad9ff4b25d0cfbceac9c9c522d496f8513338a9426991
-                 2e0bbd2b2c500b303dae963b707ed4a05e9f57eb0c7de06da884669a93dbb29b
-                 3d262e7c98e24f8cd68d0ea44fe9d5e4e0b033b0c3f77193cdf2163dfac30da9
-                 eb39b147e2d9746dd1149ac512920d8e8316577e6713498beb7fa838a80b1736
-                 383001d5151582a16bcf9fcc38edbafaf18ab976e01a0244b462c6b6f907ba14
-                 32d14e641961c3d48e300ec5561424c4b8125cf172d06f9368bfdec0d5c57b8b"
+                "74cc6e00677ea1683c3c3fbc6337101db4e2ffdd0053a8783fd4c9f5b53117db"
+                "9089ce3beef287cbe273a7c47ad1e88509842f9a70ff354280dc7a8e1c61214a"
+                "e698b4186af5628a28dad9ff4b25d0cfbceac9c9c522d496f8513338a9426991"
+                "2e0bbd2b2c500b303dae963b707ed4a05e9f57eb0c7de06da884669a93dbb29b"
+                "3d262e7c98e24f8cd68d0ea44fe9d5e4e0b033b0c3f77193cdf2163dfac30da9"
+                "eb39b147e2d9746dd1149ac512920d8e8316577e6713498beb7fa838a80b1736"
+                "383001d5151582a16bcf9fcc38edbafaf18ab976e01a0244b462c6b6f907ba14"
+                "32d14e641961c3d48e300ec5561424c4b8125cf172d06f9368bfdec0d5c57b8b"
             ),
         },
         Fixture {
             secret: &hex!("ba5eba11bedabb1ebe5077edb0a710adb01dfacecab005eca11ab1eca55e77e011"),
             shared_info: &hex!("f005ba1100ddba11"),
             expected_key: &hex!(
-                "ae21b84e638fc7de4d838d2a7232655c39d2794116f00e43891170c0a16df11c
-                 15afbdb903c5722e22afc885c0f851c2ccacc2a0802437bc5bef6c18a0573246
-                 65de72200dac5321ed92f530ed441bc194c402055419d73f52165a2bf9985fab
-                 756abce8e3b9c5e4a3d179b2eceaa6ef7b335245f480ed32a7f847921ab5e3c1
-                 a8867aff9802e6f8cec4d6a5fdf3cc0c2c1a14f08ec4df3654f2579164c6ed90
-                 a2262a8d492a0aa0942838952dc89f494018da5dd16c0b18ca6a9837685489bf
-                 a55debb243045e83a730e5e08917836181693cb4ab1827e968e3bb0e8e3b9a0e
-                 7cdab180f59168211dad86eb88fc3b4bc1dbeb0c8a8c967c5e0d1b2a84bf215c"
+                "ae21b84e638fc7de4d838d2a7232655c39d2794116f00e43891170c0a16df11c"
+                "15afbdb903c5722e22afc885c0f851c2ccacc2a0802437bc5bef6c18a0573246"
+                "65de72200dac5321ed92f530ed441bc194c402055419d73f52165a2bf9985fab"
+                "756abce8e3b9c5e4a3d179b2eceaa6ef7b335245f480ed32a7f847921ab5e3c1"
+                "a8867aff9802e6f8cec4d6a5fdf3cc0c2c1a14f08ec4df3654f2579164c6ed90"
+                "a2262a8d492a0aa0942838952dc89f494018da5dd16c0b18ca6a9837685489bf"
+                "a55debb243045e83a730e5e08917836181693cb4ab1827e968e3bb0e8e3b9a0e"
+                "7cdab180f59168211dad86eb88fc3b4bc1dbeb0c8a8c967c5e0d1b2a84bf215c"
             ),
         },
     ];
@@ -179,74 +175,17 @@ fn test_input_output_sha512() {
 }
 
 #[test]
-fn test_errors() {
-    // secret has zero length.
+fn test_no_secret() {
     assert_eq!(
         ansi_x963_kdf::derive_key_into::<Sha512>(&[], &[], &mut [0u8; 42]),
         Err(ansi_x963_kdf::Error::NoSecret)
     );
+}
 
-    // key has zero length.
+#[test]
+fn test_no_output() {
     assert_eq!(
         ansi_x963_kdf::derive_key_into::<Sha512>(&[0u8; 42], &[], &mut [0u8; 0]),
         Err(ansi_x963_kdf::Error::NoOutput)
     );
-
-    // shared_info has a length that causes input overflow.
-    #[cfg(target_pointer_width = "64")]
-    {
-        // Secret
-        let secret = [0u8; 42];
-
-        // Calculate the required length for shared_info to cause an input overflow: |Z| + |SharedInfo| + 4 >= hashmaxlen
-        let shared_info_len = Sha224::output_size() * (u32::MAX as usize) - secret.len() - 4;
-
-        // Create a layout for allocation.
-        let layout = std::alloc::Layout::from_size_align(shared_info_len, 1).unwrap();
-        unsafe {
-            // We assume that OS will not allocate physical memory for this buffer
-            let p = std::alloc::alloc_zeroed(layout);
-            if p.is_null() {
-                panic!("Failed to allocate memory");
-            }
-
-            // Wrap the allocated pointer in a struct that will deallocate it on drop.
-            struct AllocGuard {
-                ptr: *mut u8,
-                layout: std::alloc::Layout,
-            }
-            impl Drop for AllocGuard {
-                fn drop(&mut self) {
-                    unsafe {
-                        std::alloc::dealloc(self.ptr, self.layout);
-                    }
-                }
-            }
-            let _guard = AllocGuard { ptr: p, layout };
-
-            // Create a slice from the allocated memory.
-            let shared_info = std::slice::from_raw_parts(p, shared_info_len);
-            assert_eq!(
-                ansi_x963_kdf::derive_key_into::<Sha224>(&secret, shared_info, &mut [0u8; 42]),
-                Err(ansi_x963_kdf::Error::InputOverflow)
-            );
-        }
-    }
-
-    // key has a length that causes counter overflow.
-    #[cfg(target_pointer_width = "64")]
-    {
-        let size = Sha224::output_size() * u32::MAX as usize;
-        let layout = std::alloc::Layout::from_size_align(size, 1).unwrap();
-        unsafe {
-            // We assume that OS will not allocate physicall memory for this buffer
-            let p = std::alloc::alloc_zeroed(layout);
-            let buf = std::slice::from_raw_parts_mut(p, size);
-            assert_eq!(
-                ansi_x963_kdf::derive_key_into::<Sha224>(&[0u8; 42], &[], buf),
-                Err(ansi_x963_kdf::Error::CounterOverflow)
-            );
-            std::alloc::dealloc(p, layout)
-        };
-    }
 }


### PR DESCRIPTION
- Add LICENSE files.
- Tweak documentation examples to remove horizontal scroll in generated docs.
- Include crate-level docs from README.
- Replace `std` crate feature with `alloc`.
- Return `Box<[u8]>` from `derive_key` instead of `Vec<u8>`.
- Add `#[inline]` attributes.
- Split `test_errors` into separate tests and remove the huge allocation tests since they may fail in some cases.