### PR TITLE
hkdf: bump MSRV to 1.81

### DIFF
--- a/.github/workflows/hkdf.yml
+++ b/.github/workflows/hkdf.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,7 @@ version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c070b79a496dccd931229780ad5bbedd535ceff6c3565605a8e440e18e1aa2b"
 dependencies = [
- "getrandom",
  "hybrid-array",
- "rand_core",
 ]
 
 [[package]]
@@ -70,17 +68,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -125,15 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "sha1"
 version = "0.11.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,9 +144,3 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/hkdf/CHANGELOG.md
+++ b/hkdf/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Breaking changes
+- Removed `std` crate feature ([#105])
+- Bump MSRV to 1.81 ([#105])
+- Bump `hmac` dependency to v0.13
+
+[#105]: https://github.com/RustCrypto/KDFs/pull/105
+
 ## 0.12.3 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#63])

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["crypto", "HKDF", "KDF"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.81"
 
 [dependencies]
 hmac = "=0.13.0-pre.4"
@@ -20,9 +20,6 @@ blobby = "0.3"
 hex-literal = "0.4"
 sha1 = { version = "=0.11.0-pre.4", default-features = false }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
-
-[features]
-std = ["hmac/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hkdf/src/errors.rs
+++ b/hkdf/src/errors.rs
@@ -10,9 +10,7 @@ impl fmt::Display for InvalidPrkLength {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl ::std::error::Error for InvalidPrkLength {}
+impl core::error::Error for InvalidPrkLength {}
 
 /// Structure for InvalidLength, used for output error handling.
 #[derive(Copy, Clone, Debug)]
@@ -24,6 +22,4 @@ impl fmt::Display for InvalidLength {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl ::std::error::Error for InvalidLength {}
+impl core::error::Error for InvalidLength {}

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -95,9 +95,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 pub use hmac;
 
 use core::fmt;


### PR DESCRIPTION
Removes the `std` crate feature as no longer needed.