### PR TITLE
Remove `alloc` crate feature from `concat-kdf` and `ansi-x963-kdf`

### DIFF
--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -18,8 +18,3 @@ digest = "=0.11.0-pre.9"
 [dev-dependencies]
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -19,9 +19,6 @@ digest = "=0.11.0-pre.9"
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
-[features]
-alloc = []
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt;
 use digest::{array::typenum::Unsigned, Digest, FixedOutputReset};

--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -5,35 +5,6 @@
 use core::fmt;
 use digest::{array::typenum::Unsigned, Digest, FixedOutputReset};
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
-/// ANSI-X9.63 KDF errors.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Error {
-    /// The length of the secret is zero.
-    NoSecret,
-    /// The length of the output is zero.
-    NoOutput,
-    /// The length of the input is too big
-    InputOverflow,
-    /// The length of the output is too big.
-    CounterOverflow,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str(match self {
-            Error::NoSecret => "Buffer for secret has zero length.",
-            Error::NoOutput => "Buffer for key has zero length.",
-            Error::InputOverflow => "Input length is to big.",
-            Error::CounterOverflow => "Requested key length is to big.",
-        })
-    }
-}
-
-impl ::core::error::Error for Error {}
-
 /// Derives `key` in-place from `secret` and `shared_info`.
 ///
 /// # Example
@@ -90,27 +61,28 @@ where
     Ok(())
 }
 
-/// Derives and returns `length` bytes key from `secret` and `shared_info`.
-///
-/// # Example
-/// ```
-/// use hex_literal::hex;
-/// use sha2::Sha256;
-///
-/// let key = ansi_x963_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 16).unwrap();
-/// assert_eq!(key[..], hex!("8dbb1d50bcc7fc782abc9db5c64a2826")[..]);
-/// ```
-#[cfg(feature = "alloc")]
-#[inline]
-pub fn derive_key<D>(
-    secret: &[u8],
-    shared_info: &[u8],
-    length: usize,
-) -> Result<alloc::boxed::Box<[u8]>, Error>
-where
-    D: Digest + FixedOutputReset,
-{
-    let mut key = alloc::vec![0u8; length].into_boxed_slice();
-    derive_key_into::<D>(secret, shared_info, &mut key)?;
-    Ok(key)
+/// ANSI-X9.63 KDF errors.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Error {
+    /// The length of the secret is zero.
+    NoSecret,
+    /// The length of the output is zero.
+    NoOutput,
+    /// The length of the input is too big
+    InputOverflow,
+    /// The length of the output is too big.
+    CounterOverflow,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(match self {
+            Error::NoSecret => "Buffer for secret has zero length.",
+            Error::NoOutput => "Buffer for key has zero length.",
+            Error::InputOverflow => "Input length is to big.",
+            Error::CounterOverflow => "Requested key length is to big.",
+        })
+    }
+}
+
+impl core::error::Error for Error {}

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -18,7 +18,3 @@ digest = "=0.11.0-pre.9"
 [dev-dependencies]
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -19,9 +19,6 @@ digest = "=0.11.0-pre.9"
 hex-literal = "0.4"
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 
-[features]
-alloc = []
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/concat-kdf/src/lib.rs
+++ b/concat-kdf/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt;
 use digest::{array::typenum::Unsigned, Digest, FixedOutputReset, Update};

--- a/concat-kdf/src/lib.rs
+++ b/concat-kdf/src/lib.rs
@@ -5,32 +5,6 @@
 use core::fmt;
 use digest::{array::typenum::Unsigned, Digest, FixedOutputReset, Update};
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
-/// Concat KDF errors.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Error {
-    /// The length of the secret is zero.
-    NoSecret,
-    /// The length of the output is zero.
-    NoOutput,
-    /// The length of the output is too big.
-    CounterOverflow,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str(match self {
-            Error::NoSecret => "Buffer for secret has zero length.",
-            Error::NoOutput => "Buffer for key has zero length.",
-            Error::CounterOverflow => "Requested key length is to big.",
-        })
-    }
-}
-
-impl ::core::error::Error for Error {}
-
 /// Derives `key` in-place from `secret` and `other_info`.
 ///
 /// # Example
@@ -73,26 +47,25 @@ where
     Ok(())
 }
 
-/// Derives and returns `length` bytes key from `secret` and `other_info`.
-///
-/// # Example
-/// ```rust
-/// use hex_literal::hex;
-/// use sha2::Sha256;
-///
-/// let key = concat_kdf::derive_key::<Sha256>(b"secret", b"shared-info", 16).unwrap();
-/// assert_eq!(key[..], hex!("960db2c549ab16d71a7b008e005c2bdc")[..]);
-/// ```
-#[cfg(feature = "alloc")]
-pub fn derive_key<D>(
-    secret: &[u8],
-    other_info: &[u8],
-    length: usize,
-) -> Result<alloc::boxed::Box<[u8]>, Error>
-where
-    D: Digest + FixedOutputReset,
-{
-    let mut key = alloc::vec![0u8; length].into_boxed_slice();
-    derive_key_into::<D>(secret, other_info, &mut key)?;
-    Ok(key)
+/// Concat KDF errors.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Error {
+    /// The length of the secret is zero.
+    NoSecret,
+    /// The length of the output is zero.
+    NoOutput,
+    /// The length of the output is too big.
+    CounterOverflow,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(match self {
+            Error::NoSecret => "Buffer for secret has zero length.",
+            Error::NoOutput => "Buffer for key has zero length.",
+            Error::CounterOverflow => "Requested key length is to big.",
+        })
+    }
+}
+
+impl core::error::Error for Error {}


### PR DESCRIPTION
The crate feature is used only for the 3-line convenience functions, which can be easily written by users and probably extremely rarely used in practice.