### PR TITLE
Use `doc_auto_cfg`

### DIFF
--- a/ansi-x963-kdf/src/lib.rs
+++ b/ansi-x963-kdf/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
 use core::fmt;

--- a/concat-kdf/src/lib.rs
+++ b/concat-kdf/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
 use core::fmt;

--- a/hkdf/src/lib.rs
+++ b/hkdf/src/lib.rs
@@ -91,7 +91,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/kbkdf/src/lib.rs
+++ b/kbkdf/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
 use core::{fmt, marker::PhantomData, ops::Mul};


### PR DESCRIPTION
Some crates do not have any crate features, but it's still worth to enable `doc_auto_cfg` for them for consistency and to future-proof them.