### PR TITLE
Bump `cipher` v0.5.0-rc.1; `digest` v0.11.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 4
 [[package]]
 name = "aes"
 version = "0.9.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
+source = "git+https://github.com/RustCrypto/block-ciphers#cbc75f837701a1114bd50748cff6cdb65e8d3c1d"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -54,8 +53,9 @@ checksum = "4a859067dcb257cb2ae028cb821399b55140b76fb8b2a360e052fe109019db43"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
 ]
@@ -68,9 +68,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "crypto-common",
  "inout",
@@ -79,7 +79,7 @@ dependencies = [
 [[package]]
 name = "cmac"
 version = "0.8.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#d1736a3f38a7c0fbbdb82e3b3ab171e526a63c57"
+source = "git+https://github.com/RustCrypto/MACs#0bbfa4c3227b5c8f76e597e832420fbe34802eae"
 dependencies = [
  "cipher",
  "dbl",
@@ -106,8 +106,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -122,8 +123,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.11.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -156,7 +158,7 @@ dependencies = [
 [[package]]
 name = "hmac"
 version = "0.13.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#d1736a3f38a7c0fbbdb82e3b3ab171e526a63c57"
+source = "git+https://github.com/RustCrypto/MACs#0bbfa4c3227b5c8f76e597e832420fbe34802eae"
 dependencies = [
  "digest",
 ]
@@ -172,8 +174,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "hybrid-array",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,11 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-# https://github.com/RustCrypto/utils/pull/1208
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
+# https://github.com/RustCrypto/block-ciphers/pull/499
+aes = { git = "https://github.com/RustCrypto/block-ciphers" }
 # https://github.com/RustCrypto/MACs/pull/206
 cmac = { git = "https://github.com/RustCrypto/MACs" }
-# https://github.com/RustCrypto/traits/pull/1976
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
 # https://github.com/RustCrypto/utils/pull/1208
 dbl = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-digest = { git = "https://github.com/RustCrypto/traits" }
 # https://github.com/RustCrypto/MACs/pull/206
 hmac = { git = "https://github.com/RustCrypto/MACs" }
-# https://github.com/RustCrypto/utils/pull/1208
-inout = { git = "https://github.com/RustCrypto/utils" }

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85"
 exclude = ["/tests/*"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.0", default-features = false, features = ["mac"] }
+digest = { version = "0.11.0-rc.1", default-features = false, features = ["mac"] }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
These notably support `hybrid-array` v0.4