### PR TITLE
Bump cipher and hash dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
-source = "git+https://github.com/RustCrypto/block-ciphers#cbc75f837701a1114bd50748cff6cdb65e8d3c1d"
+version = "0.9.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -37,9 +38,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb51c5f2d38f4751a11964ac3988a05812fdec736b15bc0424f2cec697a85728"
+checksum = "ef2092b195c205e3d29b99ee2169fc71ea8b7dd99bd34abae4cc66e4947ec56f"
 dependencies = [
  "belt-block",
  "digest",
@@ -78,8 +79,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#0bbfa4c3227b5c8f76e597e832420fbe34802eae"
+version = "0.8.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2fa99ca412f76b4656efeab943ef06f1ddd8036c31ca38f35188f173d0dc85e"
 dependencies = [
  "cipher",
  "dbl",
@@ -115,8 +117,9 @@ dependencies = [
 
 [[package]]
 name = "dbl"
-version = "0.5.0-pre"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d7a944e61df464668c5f51f56cc667396a8821434273112948ea0b66e405d7"
 dependencies = [
  "hybrid-array",
 ]
@@ -157,8 +160,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.0"
-source = "git+https://github.com/RustCrypto/MACs#0bbfa4c3227b5c8f76e597e832420fbe34802eae"
+version = "0.13.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e206bca159aebaaed410f5e78b2fe56bfc0dd5b19ecae922813b8556b8b07e"
 dependencies = [
  "digest",
 ]
@@ -203,9 +207,9 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -214,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-# https://github.com/RustCrypto/block-ciphers/pull/499
-aes = { git = "https://github.com/RustCrypto/block-ciphers" }
-# https://github.com/RustCrypto/MACs/pull/206
-cmac = { git = "https://github.com/RustCrypto/MACs" }
-# https://github.com/RustCrypto/utils/pull/1208
-dbl = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/MACs/pull/206
-hmac = { git = "https://github.com/RustCrypto/MACs" }

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -17,4 +17,4 @@ digest = "0.11.0-rc.1"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }

--- a/bake-kdf/Cargo.toml
+++ b/bake-kdf/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "bake", "stb", "kdf"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-hash = { version = "0.2.0-rc.0", default-features = false }
+belt-hash = { version = "0.2.0-rc.1", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -17,4 +17,4 @@ digest = "0.11.0-rc.1"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = "0.13.0-rc.0"
+hmac = "0.13.0-rc.1"
 
 [dev-dependencies]
 blobby = "=0.4.0-pre.0"
 hex-literal = "1"
-sha1 = { version = "0.11.0-rc.0", default-features = false }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+sha1 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -19,11 +19,11 @@ digest = { version = "0.11.0-rc.1", default-features = false, features = ["mac"]
 [dev-dependencies]
 hex-literal = "1"
 hex = "0.4"
-hmac = { version = "0.13.0-rc.0", default-features = false }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
-sha1 = { version = "0.11.0-rc.0", default-features = false }
-cmac = "0.8.0-rc.0"
-aes = "0.9.0-rc.0"
+hmac = { version = "0.13.0-rc.1", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+sha1 = { version = "0.11.0-rc.2", default-features = false }
+cmac = "0.8.0-rc.1"
+aes = "0.9.0-rc.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Uses `hybrid-array` v0.4-compatible versions