### PR TITLE
Update to `digest::EagerHash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
+checksum = "6749b668519cd7149ee3d11286a442a8a8bdc3a9d529605f579777bfccc5a4bc"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.1"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e206bca159aebaaed410f5e78b2fe56bfc0dd5b19ecae922813b8556b8b07e"
+checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
 dependencies = [
  "digest",
 ]

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.1"
+digest = "0.11.0-rc.2"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.1"
+digest = "0.11.0-rc.2"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = "0.13.0-rc.1"
+hmac = "0.13.0-rc.2"
 
 [dev-dependencies]
 blobby = "=0.4.0-pre.0"

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -14,12 +14,12 @@ rust-version = "1.85"
 exclude = ["/tests/*"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.1", default-features = false, features = ["mac"] }
+digest = { version = "0.11.0-rc.2", default-features = false, features = ["mac"] }
 
 [dev-dependencies]
 hex-literal = "1"
 hex = "0.4"
-hmac = { version = "0.13.0-rc.1", default-features = false }
+hmac = { version = "0.13.0-rc.2", default-features = false }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 sha1 = { version = "0.11.0-rc.2", default-features = false }
 cmac = "0.8.0-rc.1"


### PR DESCRIPTION
Follow-up to https://github.com/RustCrypto/traits/pull/2014.

Builds on https://github.com/RustCrypto/MACs/pull/212.