### PR TITLE
hkdf: simplify generic signatures

### DIFF
--- a/hkdf/src/hmac_impl.rs
+++ b/hkdf/src/hmac_impl.rs
@@ -7,7 +7,7 @@ use hmac::{EagerHash, Hmac, SimpleHmac};
 /// Trait representing a HMAC implementation.
 ///
 /// Most users should use [`Hmac`] or [`SimpleHmac`].
-pub trait HmacImpl<H: OutputSizeUser>: Clone {
+pub trait HmacImpl: Clone + OutputSizeUser {
     /// Create new HMAC state with the given key.
     fn new_from_slice(key: &[u8]) -> Self;
 
@@ -15,10 +15,10 @@ pub trait HmacImpl<H: OutputSizeUser>: Clone {
     fn update(&mut self, data: &[u8]);
 
     /// Finalize the HMAC state and get generated tag.
-    fn finalize(self) -> Output<H>;
+    fn finalize(self) -> Output<Self>;
 }
 
-impl<H: EagerHash> HmacImpl<H> for Hmac<H> {
+impl<H: EagerHash> HmacImpl for Hmac<H> {
     #[inline(always)]
     fn new_from_slice(key: &[u8]) -> Self {
         KeyInit::new_from_slice(key).expect("HMAC can take a key of any size")
@@ -30,13 +30,12 @@ impl<H: EagerHash> HmacImpl<H> for Hmac<H> {
     }
 
     #[inline(always)]
-    fn finalize(self) -> Output<H> {
-        Output::<H>::try_from(&self.finalize_fixed()[..])
-            .expect("Output<H> and Output<Hmac<H>> are always equal to each other")
+    fn finalize(self) -> Output<Self> {
+        self.finalize_fixed()
     }
 }
 
-impl<H> HmacImpl<H> for SimpleHmac<H>
+impl<H> HmacImpl for SimpleHmac<H>
 where
     H: Digest + BlockSizeUser + Clone,
 {
@@ -52,7 +51,6 @@ where
 
     #[inline(always)]
     fn finalize(self) -> Output<H> {
-        Output::<H>::try_from(&self.finalize_fixed()[..])
-            .expect("Output<H> and Output<SimpleHmac<H>> are always equal to each other")
+        self.finalize_fixed()
     }
 }

--- a/hkdf/tests/wycheproof.rs
+++ b/hkdf/tests/wycheproof.rs
@@ -1,14 +1,12 @@
 use blobby::Blob4Iterator;
-use hkdf::{Hkdf, HmacImpl};
+use hkdf::{GenericHkdf, HmacImpl};
 use hmac::{Hmac, SimpleHmac};
-use sha1::Sha1;
-use sha2::{Sha256, Sha384, Sha512, digest::OutputSizeUser};
 
-fn test<H: OutputSizeUser, I: HmacImpl<H>>(data: &[u8]) {
+fn test<H: HmacImpl>(data: &[u8]) {
     for (i, row) in Blob4Iterator::new(data).unwrap().enumerate() {
         let [ikm, salt, info, okm] = row.unwrap();
 
-        let prk = Hkdf::<H, I>::new(Some(salt), ikm);
+        let prk = GenericHkdf::<H>::new(Some(salt), ikm);
         let mut got_okm = vec![0; okm.len()];
 
         let mut err = None;
@@ -37,13 +35,13 @@ macro_rules! new_test {
         #[test]
         fn $name() {
             let data = include_bytes!(concat!("data/", $test_name, ".blb"));
-            test::<$hash, Hmac<$hash>>(data);
-            test::<$hash, SimpleHmac<$hash>>(data);
+            test::<Hmac<$hash>>(data);
+            test::<SimpleHmac<$hash>>(data);
         }
     };
 }
 
-new_test!(wycheproof_sha1, "wycheproof-sha1", Sha1);
-new_test!(wycheproof_sha256, "wycheproof-sha256", Sha256);
-new_test!(wycheproof_sha384, "wycheproof-sha384", Sha384);
-new_test!(wycheproof_sha512, "wycheproof-sha512", Sha512);
+new_test!(wycheproof_sha1, "wycheproof-sha1", sha1::Sha1);
+new_test!(wycheproof_sha256, "wycheproof-sha256", sha2::Sha256);
+new_test!(wycheproof_sha384, "wycheproof-sha384", sha2::Sha384);
+new_test!(wycheproof_sha512, "wycheproof-sha512", sha2::Sha512);


### PR DESCRIPTION
This PR renames `Hkdf` and `HkdfExtract` to `GenericHkdf` and `GenericHkdfExtract` respectively and simplifies their generic signature. Now the types are generic over single type `H: HmacImpl`. It also removes the generic parameter from the `HmacImpl` trait.

Finally, it introduces `HkdfExtract` and `Hkdf` aliases to simplify migration for users.