### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -38,9 +38,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2092b195c205e3d29b99ee2169fc71ea8b7dd99bd34abae4cc66e4947ec56f"
+checksum = "c4d0d625c21e8e5ca317b31568d257c4af4e93fd5a756d0301f5d517951ea6fd"
 dependencies = [
  "belt-block",
  "digest",
@@ -69,9 +69,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
  "crypto-common",
  "inout",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fa99ca412f76b4656efeab943ef06f1ddd8036c31ca38f35188f173d0dc85e"
+checksum = "a4f22bad4cbf035f087384fa49d3c5d105af29801fe3d04831a737a982d67cd0"
 dependencies = [
  "cipher",
  "dbl",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]
@@ -207,9 +207,9 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.2"
+digest = "0.11.0-rc.4"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }

--- a/bake-kdf/Cargo.toml
+++ b/bake-kdf/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "bake", "stb", "kdf"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-hash = { version = "0.2.0-rc.1", default-features = false }
+belt-hash = { version = "0.2.0-rc.3", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/concat-kdf/Cargo.toml
+++ b/concat-kdf/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.2"
+digest = "0.11.0-rc.4"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = "0.13.0-rc.2"
+hmac = "0.13.0-rc.3"
 
 [dev-dependencies]
 blobby = "=0.4.0-pre.0"
 hex-literal = "1"
-sha1 = { version = "0.11.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
+sha1 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -14,16 +14,16 @@ rust-version = "1.85"
 exclude = ["/tests/*"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.2", default-features = false, features = ["mac"] }
+digest = { version = "0.11.0-rc.4", default-features = false, features = ["mac"] }
 
 [dev-dependencies]
 hex-literal = "1"
 hex = "0.4"
-hmac = { version = "0.13.0-rc.2", default-features = false }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
-sha1 = { version = "0.11.0-rc.2", default-features = false }
-cmac = "0.8.0-rc.1"
-aes = "0.9.0-rc.1"
+hmac = { version = "0.13.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha1 = { version = "0.11.0-rc.3", default-features = false }
+cmac = "0.8.0-rc.3"
+aes = "0.9.0-rc.2"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Updates the following dependencies, mostly to handle the `rand_core` v0.10 upgrade:

- `aes` v0.9.0-rc.2
- `belt-hash` v0.2.0-rc.3
- `cipher` v0.5.0-rc.2
- `cmac` v0.8.0-rc.3
- `crypto-common` v0.2.0-rc.5
- `digest` v0.11.0-rc.4
- `hmac` v0.13.0-rc.3
- `sha1` v0.11.0-rc.3
- `sha2` v0.11.0-rc.3