### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "ansi-x963-kdf"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "bake-kdf"
-version = "0.0.1"
+version = "0.1.0-rc.0"
 dependencies = [
  "belt-hash",
  "hex-literal",
@@ -140,7 +140,7 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 dependencies = [
  "blobby",
  "hex-literal",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "kbkdf"
-version = "0.1.0-pre.0"
+version = "0.1.0-rc.0"
 dependencies = [
  "aes",
  "cmac",
@@ -198,7 +198,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "one-step-kdf"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ansi-x963-kdf"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "ANSI X9.63 Key Derivation Function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/bake-kdf/Cargo.toml
+++ b/bake-kdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bake-kdf"
-version = "0.0.1"
+version = "0.1.0-rc.0"
 description = "bake-kdf function (STB 34.101.66-2014)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hkdf"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/RustCrypto/KDFs/"

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kbkdf"
-version = "0.1.0-pre.0"
+version = "0.1.0-rc.0"
 edition = "2024"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/one-step-kdf/Cargo.toml
+++ b/one-step-kdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "one-step-kdf"
-version = "0.1.0-pre"
+version = "0.1.0-rc.0"
 description = "One-Step Key Derivation Function as defined in NIST SP 800-56C R2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `ansi-x963-kdf` v0.1.0-rc.1
- `bake-kdf` v0.1.0-rc.0
- `hkdf` v0.13.0-rc.3
- `kbkdf` v0.1.0-rc.0
- `one-step-kdf` v0.1.0-rc.0