### PR TITLE
Bump `cipher` and `digest` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
  "crypto-common",
  "inout",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "block-buffer",
  "crypto-common",

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.4"
+digest = "0.11.0-rc.5"
 
 [dev-dependencies]
 hex-literal = "1"

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85"
 exclude = ["/tests/*"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.4", default-features = false, features = ["mac"] }
+digest = { version = "0.11.0-rc.5", default-features = false, features = ["mac"] }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/one-step-kdf/Cargo.toml
+++ b/one-step-kdf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.4"
+digest = "0.11.0-rc.5"
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
Bumps these dependencies to the following versions:

- `cipher` v0.5.0-rc.3
- `digest` v0.11.0-rc.5