### PR TITLE
hkdf: impl `kdf::Kdf` for `GenericHkdfExtract`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "blobby",
  "hex-literal",
  "hmac",
+ "kdf",
  "sha1",
  "sha2",
 ]
@@ -189,6 +190,12 @@ dependencies = [
  "sha1",
  "sha2",
 ]
+
+[[package]]
+name = "kdf"
+version = "0.1.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4852c654c9650d06a4293146ead04bedcf29861dc0de1115ca1492b7a27c50aa"
 
 [[package]]
 name = "libc"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -15,6 +15,9 @@ rust-version = "1.85"
 [dependencies]
 hmac = "0.13.0-rc.3"
 
+# optional dependencies
+kdf = { version = "0.1.0-pre.1", optional = true }
+
 [dev-dependencies]
 blobby = "0.4"
 hex-literal = "1"


### PR DESCRIPTION
Due to the `&self` requirement in the `Kdf` trait, this seems like the only existing type that a `Kdf` impl makes sense for, since `derive_key` needs to be able to input IKM.

The "salt" parameter of `Kdf::derive_key` has been mapped to the HKDF `info` parameter, as what HKDF calls the "salt" (the non-secret value that goes into the extract step) has already been (potentially) configured via `&self`, whereas the "info" parameter (the non-secret value that goes into the expand step) is the one we can actually configure through this API.