### PR TITLE
Remove MSRV policy section and update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # RustCrypto: Key Derivation Functions
 
-[![Project Chat][chat-image]][chat-link] [![dependency status][deps-image]][deps-link] ![Apache2/MIT licensed][license-image]
+[![Project Chat][chat-image]][chat-link]
+[![dependency status][deps-image]][deps-link]
+![Apache2/MIT licensed][license-image]
 
 Collection of [Key Derivation Functions][KDF] (KDF) written in pure Rust.
 
@@ -8,17 +10,13 @@ Collection of [Key Derivation Functions][KDF] (KDF) written in pure Rust.
 
 | Algorithm    | Crate | Crates.io | Documentation | MSRV |
 |--------------|-------|:---------:|:-------------:|:----:|
-| [ANSI-X9.63-KDF] | [`ansi-x963-kdf`] | [![crates.io](https://img.shields.io/crates/v/ansi-x963-kdf.svg)](https://crates.io/crates/ansi-x963-kdf) | [![Documentation](https://docs.rs/ansi-x963-kdf/badge.svg)](https://docs.rs/ansi-x963-kdf) | ![MSRV 1.81][msrv-1.81] |
-| [bake-kdf]   | [`bake-kdf`]   |   [![crates.io](https://img.shields.io/crates/v/bake-kdf.svg)](https://crates.io/crates/bake-kdf)   |   [![Documentation](https://docs.rs/bake-kdf/badge.svg)](https://docs.rs/bake-kdf)   | ![MSRV 1.81][msrv-1.81] |
-| [Concat-KDF] | [`concat-kdf`] | [![crates.io](https://img.shields.io/crates/v/concat-kdf.svg)](https://crates.io/crates/concat-kdf) | [![Documentation](https://docs.rs/concat-kdf/badge.svg)](https://docs.rs/concat-kdf) | ![MSRV 1.81][msrv-1.81] |
-| [HKDF]       | [`hkdf`]       |       [![crates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf)       |       [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf)       | ![MSRV 1.81][msrv-1.81] |
-| [KBKDF]      | [`kbkdf`]      | [![crates.io](https://img.shields.io/crates/v/kbkdf.svg)](https://crates.io/crates/kbkdf)       |       [![Documentation](https://docs.rs/kbkdf/badge.svg)](https://docs.rs/kbkdf)         | ![MSRV 1.81][msrv-1.81] |
+| [ANSI-X9.63-KDF] | [`ansi-x963-kdf`] | [![crates.io](https://img.shields.io/crates/v/ansi-x963-kdf.svg)](https://crates.io/crates/ansi-x963-kdf) | [![Documentation](https://docs.rs/ansi-x963-kdf/badge.svg)](https://docs.rs/ansi-x963-kdf) | ![MSRV 1.85][msrv-1.85] |
+| [bake-kdf]   | [`bake-kdf`]   |   [![crates.io](https://img.shields.io/crates/v/bake-kdf.svg)](https://crates.io/crates/bake-kdf)   |   [![Documentation](https://docs.rs/bake-kdf/badge.svg)](https://docs.rs/bake-kdf)   | ![MSRV 1.85][msrv-1.85] |
+| [Concat-KDF] | [`concat-kdf`] | [![crates.io](https://img.shields.io/crates/v/concat-kdf.svg)](https://crates.io/crates/concat-kdf) | [![Documentation](https://docs.rs/concat-kdf/badge.svg)](https://docs.rs/concat-kdf) | ![MSRV 1.85][msrv-1.85] |
+| [HKDF]       | [`hkdf`]       |       [![crates.io](https://img.shields.io/crates/v/hkdf.svg)](https://crates.io/crates/hkdf)       |       [![Documentation](https://docs.rs/hkdf/badge.svg)](https://docs.rs/hkdf)       | ![MSRV 1.85][msrv-1.85] |
+| [KBKDF]      | [`kbkdf`]      | [![crates.io](https://img.shields.io/crates/v/kbkdf.svg)](https://crates.io/crates/kbkdf)       |       [![Documentation](https://docs.rs/kbkdf/badge.svg)](https://docs.rs/kbkdf)         | ![MSRV 1.85][msrv-1.85] |
 
 *NOTE: for password-based KDFs (e.g. Argon2, PBKDF2, scrypt), please see [RustCrypto/password-hashes]*
-
-### Minimum Supported Rust Version (MSRV) Policy
-
-MSRV bumps are considered breaking changes and will be performed only with minor version bump.
 
 ## License
 
@@ -40,7 +38,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [deps-image]: https://deps.rs/repo/github/RustCrypto/KDFs/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/KDFs
-[msrv-1.81]: https://img.shields.io/badge/rustc-1.81+-blue.svg
+[msrv-1.85]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (crates)
 


### PR DESCRIPTION
In the new released we rely on the MSRV-aware resolver.