### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d0d625c21e8e5ca317b31568d257c4af4e93fd5a756d0301f5d517951ea6fd"
+checksum = "941a75a90169bf5eceb17f40ab25f5f1077006996eb52f4e9d036a7ac378db68"
 dependencies = [
  "belt-block",
  "digest",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2bcc93d5cde6659e8649fc412894417ebc14dee54cfc6ee439c683a4a58342"
+checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
 dependencies = [
  "hybrid-array",
 ]
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca14c221bd9052fd2da7c34a2eeb5ae54732db28be47c35937be71793d675422"
+checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.3"
+version = "0.13.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
+checksum = "d9956e202a691c5c86c60303a421f66f93f44b29433407b7c43cf2bebadc750e"
 dependencies = [
  "digest",
 ]
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
+checksum = "9c777f0a122a53fddb0beb6e706771197000b8eb5c9f42b5b850f450ef48c788"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ansi-x963-kdf/Cargo.toml
+++ b/ansi-x963-kdf/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.5"
+digest = "0.11.0-rc.9"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }

--- a/bake-kdf/Cargo.toml
+++ b/bake-kdf/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["crypto", "bake", "stb", "kdf"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-belt-hash = { version = "0.2.0-rc.3", default-features = false }
+belt-hash = { version = "0.2.0-rc.4", default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"

--- a/hkdf/Cargo.toml
+++ b/hkdf/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = "0.13.0-rc.3"
+hmac = "0.13.0-rc.4"
 
 # optional dependencies
 kdf = { version = "0.1.0-pre.1", optional = true }
@@ -21,8 +21,8 @@ kdf = { version = "0.1.0-pre.1", optional = true }
 [dev-dependencies]
 blobby = "0.4"
 hex-literal = "1"
-sha1 = { version = "0.11.0-rc.3", default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha1 = { version = "0.11.0-rc.4", default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/kbkdf/Cargo.toml
+++ b/kbkdf/Cargo.toml
@@ -14,14 +14,14 @@ rust-version = "1.85"
 exclude = ["/tests/*"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.5", default-features = false, features = ["mac"] }
+digest = { version = "0.11.0-rc.9", default-features = false, features = ["mac"] }
 
 [dev-dependencies]
 hex-literal = "1"
 hex = "0.4"
-hmac = { version = "0.13.0-rc.3", default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
-sha1 = { version = "0.11.0-rc.3", default-features = false }
+hmac = { version = "0.13.0-rc.4", default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }
+sha1 = { version = "0.11.0-rc.4", default-features = false }
 cmac = "0.8.0-rc.3"
 aes = "0.9.0-rc.2"
 

--- a/one-step-kdf/Cargo.toml
+++ b/one-step-kdf/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.5"
+digest = "0.11.0-rc.9"
 
 [dev-dependencies]
 hex-literal = "1"
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }


### PR DESCRIPTION
Updates the following dependencies:

- `belt-hash` v0.2.0-rc.4
- `digest` v0.11.0-rc.9
- `hmac` v0.13.0-rc.4
- `sha1` v0.11.0-rc.4
- `sha2` v0.11.0-rc.4